### PR TITLE
Fix vercel root issue

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,6 +5,7 @@
 
 ## Useful Commands
 
+    - npm run new:project generate a new project.md file in content/projects and a new project-folder in public/projects/project and example assets
     - npm run dev
     - npm run lint (important to ensure vercel build succeeds)
     - gt create -am "your commit message"

--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -1,4 +1,4 @@
-import P5Canvas from "@/src/components/P5Canvas";
+import P5Canvas from "@/components/P5Canvas";
 import Projects from "../components/Projects";
 export const revalidate = false; // SSG at build; set to a number for ISR
 

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -20,7 +20,7 @@
             }
         ],
         "paths": {
-            "@/*": ["./*"]
+            "@/*": ["./src/*"]
         }
     },
     "include": ["next-env.d.ts", "**/*.ts", "**/*.tsx", ".next/types/**/*.ts"],


### PR DESCRIPTION
### TL;DR

Updated import paths and added documentation for the new project generation command.

### What changed?

- Added documentation in README.md for the `npm run new:project` command that generates new project files and folders
- Fixed the import path in `src/app/page.tsx` from `@/src/components/P5Canvas` to `@/components/P5Canvas`
- Updated the path alias in `tsconfig.json` from `@/*` pointing to `./*` to `@/*` pointing to `./src/*`

### How to test?

1. Verify that the application builds and runs correctly with `npm run dev`
2. Try using the `npm run new:project` command to generate a new project
3. Check that imports using the `@/` alias work correctly throughout the codebase

### Why make this change?

The path alias configuration was inconsistent with how it was being used in the codebase. This change standardizes the import paths to use `@/` to point to the `src/` directory, which is a common Next.js convention. Additionally, documenting the new project generation command helps developers understand the available tooling.