### PR TITLE
Vercel build issue

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,6 +6,7 @@
 ## Useful Commands
 
     - npm run new:project generate a new project.md file in content/projects and a new project-folder in public/projects/project and example assets
+    - npm run delete:project delete project.md, corresponding public/projects/project folder and all content in that folder
     - npm run dev
     - npm run lint (important to ensure vercel build succeeds)
     - gt create -am "your commit message"

--- a/src/lib/projects.ts
+++ b/src/lib/projects.ts
@@ -20,7 +20,12 @@ export type Project = {
 const DIR = path.join(process.cwd(), "content", "projects");
 
 export async function getAllProjects(): Promise<Project[]> {
-    const files = (await fs.readdir(DIR)).filter((f) => f.endsWith(".md"));
+    let files: string[] = [];
+    try {
+        files = (await fs.readdir(DIR)).filter((f) => f.endsWith(".md"));
+    } catch {
+        return [];
+    }
     const projects = await Promise.all(
         files.map(async (file) => {
             const slug = file.replace(/\.md$/, "");


### PR DESCRIPTION
### TL;DR

Added a new command to delete projects and improved error handling when reading project files.

### What changed?

- Added a new command `npm run delete:project` to the README.md that allows users to delete a project.md file and its corresponding folder in public/projects
- Enhanced the `getAllProjects()` function with try-catch error handling to gracefully return an empty array when the projects directory cannot be read

### How to test?

1. Run `npm run delete:project` to verify the project deletion functionality works
2. Test the `getAllProjects()` function behavior when the content/projects directory doesn't exist or is inaccessible

### Why make this change?

This change improves the developer experience by providing a convenient way to clean up unwanted projects and makes the application more robust by handling the case where the projects directory might not exist, preventing potential runtime errors.