### PR TITLE
Create project layout

### DIFF
--- a/content/projects/803-323-7638.md
+++ b/content/projects/803-323-7638.md
@@ -13,9 +13,6 @@ images:
     - "raucous.jpg"
 audio:
 ---
-
-# 803-323-7638
-
 Suspended from the ceiling, a life-sized canvas frame enclosed the performer seated on a pedestal, their body both present and withheld. Above the head, in bold lettering, hovered a phone number: 803-323-7638. Across the gallery, library index cards dangled from strings, each a directive — “text me you love me,” “text me you hate me,” “tell me about her,” “tell me about it.”
 
 The space swelled with noise: visitors shouted, laughed, jeered, and demanded acknowledgement. Yet the performer sat impassive, never responding to the din. Only through text was exchange possible. Every digital message — prank, threat, confession, erotic overture, unguarded admission — was answered.

--- a/src/components/Project.tsx
+++ b/src/components/Project.tsx
@@ -5,20 +5,26 @@ import { Project as ProjectType } from '../lib/projects'
 
 const Project = ({ p }: { p: ProjectType }) => {
   return (
-    <article key={p.slug}>
-      <h2>{p.title}</h2>
-      <p>
-        {p.dates}
-        {p.location ? ` • ${p.location}` : ''}
-      </p>
-
-      {p.description && <p>{p.description}</p>}
-      <div style={{ maxWidth: 500, margin: '0 auto' }}>
+    <article
+      className='project'
+      key={p.slug}
+      style={{ display: 'flex', flexDirection: 'row', gap: 20, minHeight: 500 }}
+    >
+      <div style={{ flex: '0 0 700px', maxWidth: 700 }}>
         <Images images={p.images} alt={p.title} />
       </div>
-
-      {/* Markdown body */}
-      <div dangerouslySetInnerHTML={{ __html: p.contentHtml }} />
+      <div style={{ display: 'flex', flexDirection: 'column', gap: 30 }}>
+        <Information
+          title={p.title}
+          location={p.location}
+          dates={p.dates}
+          description={p.description}
+        />
+        <div
+          style={{ display: 'flex', flexDirection: 'column', gap: 10 }}
+          dangerouslySetInnerHTML={{ __html: p.contentHtml }}
+        />
+      </div>
 
       {p.audio &&
         p.audio.length > 0 &&
@@ -33,6 +39,48 @@ const Project = ({ p }: { p: ProjectType }) => {
   )
 }
 
+const Information = ({
+  title,
+  dates,
+  location,
+  description,
+}: {
+  title: string
+  location: string | undefined
+  dates: string
+  description: string | undefined
+}) => {
+  return (
+    <div
+      className='information'
+      style={{
+        display: 'flex',
+        flexDirection: 'column',
+        justifyContent: 'space-between',
+      }}
+    >
+      <div
+        className='title'
+        style={{
+          display: 'flex',
+          flexDirection: 'row',
+          justifyContent: 'space-between',
+        }}
+      >
+        <h2 style={{ fontSize: 24, fontWeight: 'bold' }}>{title}</h2>
+        <p style={{ fontSize: 16, color: '#333' }}>
+          {dates}
+          {location ? ` • ${location}` : ''}
+        </p>
+      </div>
+
+      {description && (
+        <p style={{ fontSize: 14, fontStyle: 'italic' }}>{description}</p>
+      )}
+    </div>
+  )
+}
+
 const Images = ({
   images,
   alt = '',
@@ -41,8 +89,9 @@ const Images = ({
   alt?: string
 }) => {
   const [active, setActive] = useState(0)
+
   return (
-    <div style={{ display: 'flex', gap: 12, height: 360, width: '100%' }}>
+    <div style={{ display: 'flex', gap: 12, height: 700, width: '100%' }}>
       {images &&
         images.length > 0 &&
         images.map((img, i) => {
@@ -53,14 +102,16 @@ const Images = ({
               onClick={() => setActive(i)}
               style={{
                 all: 'unset',
+                display: 'block',
                 cursor: 'pointer',
-                flexGrow: isActive ? 8 : 1,
+                flexGrow: isActive ? 10 : 1,
                 transition: 'flex-grow 350ms ease',
                 position: 'relative',
                 overflow: 'hidden',
                 borderRadius: 1,
                 height: '100%',
-                minWidth: 40,
+                minWidth: 20,
+                flexBasis: 0,
               }}
             >
               <Image

--- a/src/components/Projects.tsx
+++ b/src/components/Projects.tsx
@@ -3,7 +3,7 @@ import Project from './Project'
 export default async function Projects() {
   const projects = await getAllProjects()
   return (
-    <section className=''>
+    <section style={{ display: 'flex', flexDirection: 'column', gap: 50 }}>
       {projects.map((p) => (
         <Project p={p} key={p.slug} />
       ))}


### PR DESCRIPTION
### TL;DR

Redesigned project layout with a new two-column format and improved image gallery.

### What changed?

- Removed redundant title heading from the 803-323-7638 project markdown file
- Completely restructured the Project component with a new two-column layout:
  - Left column: Larger image gallery (700px width)
  - Right column: Project information and content
- Created a new Information component to display project metadata
- Enhanced the image gallery with improved styling and transitions
- Added consistent spacing between projects in the Projects component

### How to test?

1. Navigate to the projects page
2. Verify the new two-column layout displays correctly
3. Check that the image gallery expands/contracts properly when clicking different images
4. Confirm project information (title, dates, location) appears correctly in the right column
5. Ensure the 803-323-7638 project displays without a redundant title

### Why make this change?

The new layout provides a more visually appealing and organized presentation of projects. The two-column design creates a better balance between images and text, while the enhanced image gallery offers a more interactive experience. This change improves overall readability and user experience when browsing through the portfolio.