### PR TITLE
Finish styling prototype of portfolio

### DIFF
--- a/README.md
+++ b/README.md
@@ -17,4 +17,9 @@
 
 ## TODO
 
+-   [ ] How to order projects?
+-   [ ] Add other art projects
+    -   [ ] Review emails
+-   [ ] Add hash based navigation to move between projects
+-   [ ] Day/Night mode?
 -   [ ] Checks for project: is the slug valid? does the folder exist in public > projects? do all the referenced images and audio exist?

--- a/content/projects/drone-strike-in-memoriam.md
+++ b/content/projects/drone-strike-in-memoriam.md
@@ -8,9 +8,6 @@ images:
     - "unnamed.jpg"
 audio:
 ---
-
-# Drone Strike: In Memoriam
-
 At sunset, a runway of votive candles was lit — one for every child killed by United States drone strikes in Yemen, Pakistan, and other regions as of the date of the performance. Each candle carried a name, written by hand, and placed in parrellel lines stretching across the space like a landing strip.
 
 Performers and audience members moved slowly along the path, reading the names aloud as they walked. Some candles went dark almost immediately, blown out by gusts of wind entering through the open doors. Others burned for hours, until their wax pooled and the wicks disappeared.

--- a/content/projects/geographic-chat-transportation.md
+++ b/content/projects/geographic-chat-transportation.md
@@ -7,9 +7,6 @@ mediaRoot: "/projects/geographic-chat-transportation/"
 images:
     - "unnamed.jpg"
 ---
-
-# Geographic Chat Transportation
-
 A projection connected the gallery to an online chat roulette platform. On the wall, a live feed of random chat participants appeared at large scale. A webcam aimed at the projected surface captured the audience and sent their image back to the unwitting virtual participant.
 
 At the front of the space, a single button let visitors move to the next connection. Each press brought a new face into the room and sent the gallery’s image back out into the network.

--- a/content/projects/snapping-turtle-wishing-well.md
+++ b/content/projects/snapping-turtle-wishing-well.md
@@ -12,9 +12,6 @@ images:
     - "snaprabbit.JPG"
 audio:
 ---
-
-# Snapping Turtle || Wishing Well
-
 Installed in a defunct storefront in Morningside Heights, Snapping Turtle || Wishing Well reconfigured the architecture of commerce into an ecology of myth. A series of panels, painted with clay from our ancestral river, narrated the Catawba story of Rabbit stealing water from Snapping Turtle and encircled a hand-built pond at the center of the space. The artist, costumed in a swim garment, occupied the pond in a state of perpetual saturation: reclining, standing, singing.
 
 An umbrella retrofitted as conduit became both absurd and sacred technology — a pump feeding water upward only to cascade back down, endlessly re-drenching the body beneath. Within this aqueous cycle, the artist layered oral performance: songs of water, the retelling of the Rabbit and Snapping Turtle story, recitations from the International Declaration on the Rights of Water, and songs of honor for the nascent #IdleNoMore movement.

--- a/src/components/Project.tsx
+++ b/src/components/Project.tsx
@@ -3,12 +3,19 @@ import Image from 'next/image'
 import { useState } from 'react'
 import { Project as ProjectType } from '../lib/projects'
 
-const Project = ({ p }: { p: ProjectType }) => {
+const Project = ({ p, color }: { p: ProjectType; color: string }) => {
   return (
     <article
       className='project'
       key={p.slug}
-      style={{ display: 'flex', flexDirection: 'row', gap: 20, minHeight: 500 }}
+      style={{
+        display: 'flex',
+        flexDirection: 'row',
+        gap: 20,
+        minHeight: 500,
+        paddingTop: 20,
+        paddingBottom: 20,
+      }}
     >
       <div style={{ flex: '0 0 700px', maxWidth: 700 }}>
         <Images images={p.images} alt={p.title} />

--- a/src/components/Projects.tsx
+++ b/src/components/Projects.tsx
@@ -1,12 +1,27 @@
 import { getAllProjects } from '../lib/projects'
 import Project from './Project'
+const colors = [
+  '#fe9aaa',
+  '#fea741',
+  '#d19d3a',
+  '#f7f58c',
+  '#c1fc40',
+  '#2dfe50',
+  '#34feaf',
+  '#65ffea',
+  '#90c7fc',
+  '#5c86e1',
+  '#97abfb',
+  '#d975e2',
+  '#e55ca2',
+]
 export default async function Projects() {
   const projects = await getAllProjects()
   return (
-    <section style={{ display: 'flex', flexDirection: 'column', gap: 50 }}>
-      {projects.map((p) => (
-        <Project p={p} key={p.slug} />
-      ))}
+    <section style={{ display: 'flex', flexDirection: 'column' }}>
+      {projects.map((p, i) => {
+        return <Project p={p} key={p.slug} color={colors[i]} />
+      })}
     </section>
   )
 }


### PR DESCRIPTION
### TL;DR

Removed duplicate titles from project pages and improved project display with spacing and color assignments.

### What changed?

- Removed the redundant markdown titles from project content files (drone-strike-in-memoriam.md, geographic-chat-transportation.md, and snapping-turtle-wishing-well.md)
- Added padding to project components for better spacing
- Implemented a color array and passed color props to each Project component
- Updated the README.md TODO list with new items for project ordering, additional art projects, hash-based navigation, and day/night mode

### How to test?

1. Check that project pages display correctly without duplicate titles
2. Verify the spacing between projects looks consistent with the new padding
3. Confirm that each project receives a unique color from the color array

### Why make this change?

The project pages were displaying duplicate titles - once from the markdown content and once from the component rendering. This change streamlines the display by removing redundancy while improving the visual presentation with better spacing between projects. The color array implementation prepares for potential visual differentiation between projects.