### PR TITLE
Add contact form

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -39,3 +39,5 @@ yarn-error.log*
 # typescript
 *.tsbuildinfo
 next-env.d.ts
+
+.env*

--- a/package-lock.json
+++ b/package-lock.json
@@ -21,6 +21,7 @@
         "react-dom": "19.2.3",
         "remark-html": "^16.0.1",
         "remark-parse": "^11.0.0",
+        "resend": "^6.6.0",
         "tailwind-merge": "^3.2.0",
         "unified": "^11.0.5",
         "zod": "^3.25.76"
@@ -1310,6 +1311,12 @@
       "resolved": "https://registry.npmjs.org/@rtsao/scc/-/scc-1.1.0.tgz",
       "integrity": "sha512-zt6OdqaDoOnJ1ZYsCYGt9YmWzDXl4vQdKTyJev62gFhRGKdx7mcT54V9KIjg+d2wi9EXsPvAPKe7i7WjfVWB8g==",
       "dev": true
+    },
+    "node_modules/@stablelib/base64": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/@stablelib/base64/-/base64-1.0.1.tgz",
+      "integrity": "sha512-1bnPQqSxSuc3Ii6MhBysoWCg58j97aUjuCSZrGSmDxNqtytIi0k8utUenAwTZN4V5mXXYGsVUI9zeBqy+jBOSQ==",
+      "license": "MIT"
     },
     "node_modules/@swc/helpers": {
       "version": "0.5.15",
@@ -3127,6 +3134,12 @@
         "url": "https://github.com/sponsors/ljharb"
       }
     },
+    "node_modules/es6-promise": {
+      "version": "4.2.8",
+      "resolved": "https://registry.npmjs.org/es6-promise/-/es6-promise-4.2.8.tgz",
+      "integrity": "sha512-HJDGx5daxeIvxdBxvG2cb9g4tEvwIk3i8+nhX0yGrYmZUzbkdg8QbDevheDB8gd0//uPj4c1EQua8Q+MViT0/w==",
+      "license": "MIT"
+    },
     "node_modules/escalade": {
       "version": "3.2.0",
       "resolved": "https://registry.npmjs.org/escalade/-/escalade-3.2.0.tgz",
@@ -3677,6 +3690,12 @@
       "resolved": "https://registry.npmjs.org/fast-levenshtein/-/fast-levenshtein-2.0.6.tgz",
       "integrity": "sha512-DCXu6Ifhqcks7TZKY3Hxp3y6qphY5SJZmrWMDrKcERSOXWQdMhU9Ig/PYrzyw/ul9jOIyh0N4M0tbC5hodg8dw==",
       "dev": true
+    },
+    "node_modules/fast-sha256": {
+      "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/fast-sha256/-/fast-sha256-1.3.0.tgz",
+      "integrity": "sha512-n11RGP/lrWEFI/bWdygLxhI+pVeo1ZYIVwvvPkW7azl/rOy+F3HYRZ2K5zeE9mmkhQppyv9sQFx0JM9UabnpPQ==",
+      "license": "Unlicense"
     },
     "node_modules/fastq": {
       "version": "1.20.1",
@@ -6171,6 +6190,12 @@
         "node": ">=6"
       }
     },
+    "node_modules/querystringify": {
+      "version": "2.2.0",
+      "resolved": "https://registry.npmjs.org/querystringify/-/querystringify-2.2.0.tgz",
+      "integrity": "sha512-FIqgj2EUvTa7R50u0rGsyTftzjYmv/a3hO345bZNrqabNqjtgiDMgmo4mkUjd+nzU5oF3dClKqFIPUKybUyqoQ==",
+      "license": "MIT"
+    },
     "node_modules/queue-microtask": {
       "version": "1.2.3",
       "resolved": "https://registry.npmjs.org/queue-microtask/-/queue-microtask-1.2.3.tgz",
@@ -6292,6 +6317,32 @@
       "funding": {
         "type": "opencollective",
         "url": "https://opencollective.com/unified"
+      }
+    },
+    "node_modules/requires-port": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/requires-port/-/requires-port-1.0.0.tgz",
+      "integrity": "sha512-KigOCHcocU3XODJxsu8i/j8T9tzT4adHiecwORRQ0ZZFcp7ahwXuRU1m+yuO90C5ZUyGeGfocHDI14M3L3yDAQ==",
+      "license": "MIT"
+    },
+    "node_modules/resend": {
+      "version": "6.6.0",
+      "resolved": "https://registry.npmjs.org/resend/-/resend-6.6.0.tgz",
+      "integrity": "sha512-d1WoOqSxj5x76JtQMrieNAG1kZkh4NU4f+Je1yq4++JsDpLddhEwnJlNfvkCzvUuZy9ZquWmMMAm2mENd2JvRw==",
+      "license": "MIT",
+      "dependencies": {
+        "svix": "1.76.1"
+      },
+      "engines": {
+        "node": ">=20"
+      },
+      "peerDependencies": {
+        "@react-email/render": "*"
+      },
+      "peerDependenciesMeta": {
+        "@react-email/render": {
+          "optional": true
+        }
       }
     },
     "node_modules/resolve": {
@@ -6892,6 +6943,35 @@
         "url": "https://github.com/sponsors/ljharb"
       }
     },
+    "node_modules/svix": {
+      "version": "1.76.1",
+      "resolved": "https://registry.npmjs.org/svix/-/svix-1.76.1.tgz",
+      "integrity": "sha512-CRuDWBTgYfDnBLRaZdKp9VuoPcNUq9An14c/k+4YJ15Qc5Grvf66vp0jvTltd4t7OIRj+8lM1DAgvSgvf7hdLw==",
+      "license": "MIT",
+      "dependencies": {
+        "@stablelib/base64": "^1.0.0",
+        "@types/node": "^22.7.5",
+        "es6-promise": "^4.2.8",
+        "fast-sha256": "^1.3.0",
+        "url-parse": "^1.5.10",
+        "uuid": "^10.0.0"
+      }
+    },
+    "node_modules/svix/node_modules/@types/node": {
+      "version": "22.19.3",
+      "resolved": "https://registry.npmjs.org/@types/node/-/node-22.19.3.tgz",
+      "integrity": "sha512-1N9SBnWYOJTrNZCdh/yJE+t910Y128BoyY+zBLWhL3r0TYzlTmFdXrPwHL9DyFZmlEXNQQolTZh3KHV31QDhyA==",
+      "license": "MIT",
+      "dependencies": {
+        "undici-types": "~6.21.0"
+      }
+    },
+    "node_modules/svix/node_modules/undici-types": {
+      "version": "6.21.0",
+      "resolved": "https://registry.npmjs.org/undici-types/-/undici-types-6.21.0.tgz",
+      "integrity": "sha512-iwDZqg0QAGrg9Rav5H4n0M64c3mkR59cJ6wQp+7C4nI0gsmExaedaYLNO44eT4AtBBwjbTiGPMlt2Md0T9H9JQ==",
+      "license": "MIT"
+    },
     "node_modules/tailwind-merge": {
       "version": "3.2.0",
       "resolved": "https://registry.npmjs.org/tailwind-merge/-/tailwind-merge-3.2.0.tgz",
@@ -7340,6 +7420,29 @@
       "dev": true,
       "dependencies": {
         "punycode": "^2.1.0"
+      }
+    },
+    "node_modules/url-parse": {
+      "version": "1.5.10",
+      "resolved": "https://registry.npmjs.org/url-parse/-/url-parse-1.5.10.tgz",
+      "integrity": "sha512-WypcfiRhfeUP9vvF0j6rw0J3hrWrw6iZv3+22h6iRMJ/8z1Tj6XfLP4DsUix5MhMPnXpiHDoKyoZ/bdCkwBCiQ==",
+      "license": "MIT",
+      "dependencies": {
+        "querystringify": "^2.1.1",
+        "requires-port": "^1.0.0"
+      }
+    },
+    "node_modules/uuid": {
+      "version": "10.0.0",
+      "resolved": "https://registry.npmjs.org/uuid/-/uuid-10.0.0.tgz",
+      "integrity": "sha512-8XkAphELsDnEGrDxUOHB3RGvXz6TeuYSGEZBOjtTtPm2lwhGBjLgOzLHB63IUWfBpNucQjND6d3AOudO+H3RWQ==",
+      "funding": [
+        "https://github.com/sponsors/broofa",
+        "https://github.com/sponsors/ctavan"
+      ],
+      "license": "MIT",
+      "bin": {
+        "uuid": "dist/bin/uuid"
       }
     },
     "node_modules/vfile": {

--- a/package.json
+++ b/package.json
@@ -24,6 +24,7 @@
     "react-dom": "19.2.3",
     "remark-html": "^16.0.1",
     "remark-parse": "^11.0.0",
+    "resend": "^6.6.0",
     "tailwind-merge": "^3.2.0",
     "unified": "^11.0.5",
     "zod": "^3.25.76"

--- a/src/app/api/contact/route.tsx
+++ b/src/app/api/contact/route.tsx
@@ -1,0 +1,85 @@
+import { NextResponse } from 'next/server'
+import { Resend } from 'resend'
+
+export const runtime = 'nodejs' // Resend works best in Node runtime
+
+const resend = new Resend(process.env.RESEND_API_KEY)
+
+function isValidEmail(email: string) {
+  return /^[^\s@]+@[^\s@]+\.[^\s@]+$/.test(email)
+}
+
+export async function POST(req: Request) {
+  try {
+    const body = await req.json()
+
+    const name = String(body?.name ?? '').trim()
+    const email = String(body?.email ?? '').trim()
+    const message = String(body?.message ?? '').trim()
+
+    // Honeypot: include a hidden "website" input on the client
+    const website = String(body?.website ?? '').trim()
+    if (website) {
+      // Silently succeed to avoid tipping off bots
+      return NextResponse.json({ ok: true }, { status: 200 })
+    }
+
+    if (!name || !email || !message) {
+      return NextResponse.json(
+        { error: 'Missing required fields.' },
+        { status: 400 }
+      )
+    }
+    if (!isValidEmail(email)) {
+      return NextResponse.json(
+        { error: 'Invalid email address.' },
+        { status: 400 }
+      )
+    }
+    if (message.length > 5000) {
+      return NextResponse.json(
+        { error: 'Message is too long.' },
+        { status: 400 }
+      )
+    }
+
+    const from = process.env.CONTACT_FROM_EMAIL
+    const bcc = process.env.CONTACT_BCC_EMAIL
+
+    if (!process.env.RESEND_API_KEY || !from || !bcc) {
+      return NextResponse.json(
+        { error: 'Server is not configured.' },
+        { status: 500 }
+      )
+    }
+
+    // Send one email: to submitter, BCC you
+    const subject = `Thanks for reaching out, ${name}!`
+
+    const result = await resend.emails.send({
+      from,
+      to: email,
+      bcc,
+      replyTo: email,
+      subject,
+      text: `Hi ${name},
+
+Thanks for your message — I received it and will follow up soon.
+
+Your message:
+--------------------
+${message}
+--------------------
+
+— DeLesslin`,
+    })
+
+    if (result.error) {
+      return NextResponse.json({ error: result.error.message }, { status: 502 })
+    }
+
+    return NextResponse.json({ ok: true }, { status: 200 })
+  } catch {
+    return NextResponse.json({ error: 'Invalid request.' }, { status: 400 })
+  }
+}

--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -1,5 +1,7 @@
 import MotionTitle from '@/components/MotionTitle'
 import P5Canvas from '@/components/P5Canvas'
+
+import Contact from '@/components/Contact'
 import Projects from '../components/Projects'
 export const revalidate = false // SSG at build; set to a number for ISR
 
@@ -14,6 +16,7 @@ export default function Home() {
       </header>
       <main>
         <Projects />
+        <Contact />
       </main>
     </>
   )

--- a/src/components/Contact.tsx
+++ b/src/components/Contact.tsx
@@ -1,0 +1,20 @@
+import ContactForm from './ContactForm'
+const Contact = () => {
+  const color = '#333'
+  return (
+    <section
+      className='border-l-16 min-h-[500px] flex mb-12'
+      style={{ borderColor: color }}
+    >
+      <div className='mx-4 flex-1 p-4' style={{ backgroundColor: color }}>
+        <h3 className='text-2xl text-white font-bold opacity-90'>Contact</h3>
+        <h4 className='text-white opacity-80 text-lg'>
+          Have a question, idea, or project you want to discuss?
+        </h4>
+        <ContactForm />
+      </div>
+    </section>
+  )
+}
+
+export default Contact

--- a/src/components/ContactForm.tsx
+++ b/src/components/ContactForm.tsx
@@ -1,0 +1,91 @@
+'use client'
+
+import { useState } from 'react'
+
+export default function ContactForm() {
+  const [status, setStatus] = useState<'idle' | 'sending' | 'sent' | 'error'>(
+    'idle'
+  )
+  const [error, setError] = useState<string | null>(null)
+
+  async function onSubmit(e: React.FormEvent<HTMLFormElement>) {
+    e.preventDefault()
+    setStatus('sending')
+    setError(null)
+
+    const form = e.currentTarget
+    const formData = new FormData(form)
+
+    const payload = {
+      name: String(formData.get('name') ?? ''),
+      email: String(formData.get('email') ?? ''),
+      message: String(formData.get('message') ?? ''),
+      website: String(formData.get('website') ?? ''), // honeypot
+    }
+
+    const res = await fetch('/api/contact', {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify(payload),
+    })
+
+    if (!res.ok) {
+      const data = await res.json().catch(() => ({}))
+      setStatus('error')
+      setError(data?.error ?? 'Something went wrong.')
+      return
+    }
+
+    setStatus('sent')
+    form.reset()
+  }
+
+  return (
+    <form onSubmit={onSubmit} className='space-y-4'>
+      <label className='block text-white opacity-80'>
+        <span>Name</span>
+        <input name='name' required className='w-full border p-2' />
+      </label>
+
+      <label className='block text-white opacity-80'>
+        <span>Email</span>
+        <input
+          name='email'
+          type='email'
+          required
+          className='w-full border p-2'
+        />
+      </label>
+
+      <label className='block text-white opacity-80'>
+        <span>Message</span>
+        <textarea
+          name='message'
+          required
+          rows={6}
+          className='w-full border p-2'
+        />
+      </label>
+
+      {/* Honeypot: hide from humans, bots may fill */}
+      <input
+        name='website'
+        tabIndex={-1}
+        autoComplete='off'
+        className='hidden'
+        aria-hidden='true'
+      />
+
+      <button
+        type='submit'
+        disabled={status === 'sending'}
+        className='border px-4 py-2 text-white opacity-80'
+      >
+        {status === 'sending' ? 'Sending...' : 'Send'}
+      </button>
+
+      {status === 'sent' && <p>Thanks — message sent.</p>}
+      {status === 'error' && <p className='text-red-600'>{error}</p>}
+    </form>
+  )
+}


### PR DESCRIPTION
### TL;DR

Added a contact form with email functionality using Resend.

### What changed?

- Added a contact form component to the homepage
- Created a new API route (`/api/contact/route.tsx`) to handle form submissions
- Integrated Resend for email delivery
- Added honeypot protection against spam submissions
- Updated `.gitignore` to exclude environment files (`.env*`)

### How to test?

1. Set up the required environment variables:
   - `RESEND_API_KEY`
   - `CONTACT_FROM_EMAIL`
   - `CONTACT_BCC_EMAIL`
2. Fill out the contact form with name, email, and message
3. Submit the form and verify:
   - Success message appears
   - Email is sent to the submitter
   - BCC is sent to the configured email address

### Why make this change?

This adds a direct way for visitors to get in touch through the website without exposing email addresses to scrapers. The implementation includes validation, spam protection via honeypot field, and a clean user experience with appropriate feedback states.