### PR TITLE
WILL THIS WORK

### DIFF
--- a/src/app/api/contact/route.ts
+++ b/src/app/api/contact/route.ts
@@ -1,100 +1,115 @@
 import { NextResponse } from 'next/server'
-// import { Resend } from 'resend'
+import { Resend } from 'resend'
 
 export const runtime = 'nodejs'
 
-// function isValidEmail(email: string) {
-//   return /^[^\s@]+@[^\s@]+\.[^\s@]+$/.test(email)
-// }
+function isValidEmail(email: string) {
+  return /^[^\s@]+@[^\s@]+\.[^\s@]+$/.test(email)
+}
 
 export async function POST(req: Request) {
-  // const apiKey = process.env.RESEND_API_KEY
-  // const from = process.env.CONTACT_FROM_EMAIL
-  // const bcc = process.env.CONTACT_BCC_EMAIL
-  return NextResponse.json(
-    { ok: false, debug: 'route reached' },
-    { status: 418 }
-  )
+  const apiKey = process.env.RESEND_API_KEY
+  const from = process.env.CONTACT_FROM_EMAIL
+  const bcc = process.env.CONTACT_BCC_EMAIL
 
-  //   // Helpful: tell yourself WHICH env var is missing
-  //   if (!apiKey || !from || !bcc) {
-  //     console.error('Contact route misconfigured', {
-  //       hasApiKey: Boolean(apiKey),
-  //       hasFrom: Boolean(from),
-  //       hasBcc: Boolean(bcc),
-  //     })
-  //     return NextResponse.json(
-  //       { error: 'Server is not configured.' },
-  //       { status: 500 }
-  //     )
-  //   }
+  // TEMP: show config presence (not values)
+  if (!apiKey || !from || !bcc) {
+    return NextResponse.json(
+      {
+        ok: false,
+        error: 'Server misconfigured',
+        debug: {
+          hasApiKey: Boolean(apiKey),
+          hasFrom: Boolean(from),
+          hasBcc: Boolean(bcc),
+        },
+      },
+      { status: 500 }
+    )
+  }
 
-  //   const resend = new Resend(apiKey)
+  let body: any
+  try {
+    body = await req.json()
+  } catch {
+    return NextResponse.json(
+      { ok: false, error: 'Body was not valid JSON' },
+      { status: 400 }
+    )
+  }
 
-  //   try {
-  //     const body = await req.json()
+  const name = String(body?.name ?? '').trim()
+  const email = String(body?.email ?? '').trim()
+  const message = String(body?.message ?? '').trim()
+  const website = String(body?.website ?? '').trim()
 
-  //     const name = String(body?.name ?? '').trim()
-  //     const email = String(body?.email ?? '').trim()
-  //     const message = String(body?.message ?? '').trim()
+  // Honeypot
+  if (website) {
+    return NextResponse.json({ ok: true }, { status: 200 })
+  }
 
-  //     const website = String(body?.website ?? '').trim()
-  //     if (website) {
-  //       return NextResponse.json({ ok: true }, { status: 200 })
-  //     }
+  // TEMP: echo what server received (safe)
+  if (!name || !email || !message) {
+    return NextResponse.json(
+      {
+        ok: false,
+        error: 'Validation failed',
+        debug: {
+          nameLen: name.length,
+          emailLen: email.length,
+          messageLen: message.length,
+        },
+      },
+      { status: 400 }
+    )
+  }
 
-  //     if (!name || !email || !message) {
-  //       return NextResponse.json(
-  //         { error: 'Missing required fields.' },
-  //         { status: 400 }
-  //       )
-  //     }
-  //     if (!isValidEmail(email)) {
-  //       return NextResponse.json(
-  //         { error: 'Invalid email address.' },
-  //         { status: 400 }
-  //       )
-  //     }
-  //     if (message.length > 5000) {
-  //       return NextResponse.json(
-  //         { error: 'Message is too long.' },
-  //         { status: 400 }
-  //       )
-  //     }
+  if (!isValidEmail(email)) {
+    return NextResponse.json(
+      { ok: false, error: 'Invalid email address' },
+      { status: 400 }
+    )
+  }
 
-  //     const subject = `Thanks for reaching out, ${name}!`
+  const resend = new Resend(apiKey)
 
-  //     const result = await resend.emails.send({
-  //       from,
-  //       to: email,
-  //       bcc,
-  //       replyTo: email,
-  //       subject,
-  //       text: `Hi ${name},
+  try {
+    const subject = `Thanks for reaching out, ${name}!`
 
-  // Thanks for your message — I received it and will follow up soon.
+    const result = await resend.emails.send({
+      from,
+      to: email,
+      bcc,
+      replyTo: email,
+      subject,
+      text: `Hi ${name},
 
-  // Your message:
-  // --------------------
-  // ${message}
-  // --------------------
+Thanks for your message — I received it and will follow up soon.
 
-  // — DeLesslin`,
-  //     })
+Your message:
+--------------------
+${message}
+--------------------
 
-  //     if (result.error) {
-  //       console.error('Resend error:', result.error)
-  //       return NextResponse.json({ error: result.error.message }, { status: 502 })
-  //     }
+— DeLesslin`,
+    })
 
-  //     return NextResponse.json({ ok: true }, { status: 200 })
-  //     // eslint-disable-next-line @typescript-eslint/no-explicit-any
-  //   } catch (err: any) {
-  //     // This will show up in Vercel function logs
-  //     console.error('Contact route failed:', err)
-  //     return NextResponse.json(
-  //       { error: err?.message ?? 'Internal Server Error' },
-  //       { status: 500 }
-  //     )
-  //   }
+    if (result.error) {
+      return NextResponse.json(
+        { ok: false, error: 'Resend error', debug: result.error },
+        { status: 502 }
+      )
+    }
+
+    return NextResponse.json({ ok: true }, { status: 200 })
+  } catch (err: any) {
+    return NextResponse.json(
+      {
+        ok: false,
+        error: 'Unhandled exception',
+        debug: String(err?.message ?? err),
+      },
+      { status: 500 }
+    )
+  }
 }


### PR DESCRIPTION
### TL;DR

Enabled the contact form email functionality by implementing the Resend email service integration.

### What changed?

- Uncommented and implemented the email sending functionality in the contact form API route
- Added proper validation for form inputs (name, email, message)
- Implemented honeypot protection against spam submissions
- Added detailed error handling with debug information
- Structured the response format to consistently include `ok` status
- Added better environment variable validation with specific error messages

### How to test?

1. Set the required environment variables:
   - `RESEND_API_KEY`
   - `CONTACT_FROM_EMAIL`
   - `CONTACT_BCC_EMAIL`
2. Submit the contact form with valid data
3. Verify that an email is sent to the provided address
4. Test validation by submitting invalid data (empty fields, invalid email)
5. Check that the honeypot field (`website`) properly prevents spam submissions

### Why make this change?

The contact form was previously disabled and returning a teapot status code (418). This change enables the actual functionality, allowing visitors to send messages through the contact form and receive confirmation emails, while implementing proper validation and spam protection.