### PR TITLE
Make new-song script and create example

### DIFF
--- a/content/songs/fake-it.md
+++ b/content/songs/fake-it.md
@@ -1,0 +1,24 @@
+---
+type: "song"
+name: "Fake It"
+slug: "fake-it"
+releaseDate: "2026"
+language: ""
+description: ""
+mediaRoot: "/songs/fake-it/"
+
+streamingLinks:
+  []
+
+audio:
+  files:
+    - "track.mp3"
+  links:
+    []
+
+images:
+  []
+---
+
+# Fake It
+

--- a/package.json
+++ b/package.json
@@ -5,6 +5,7 @@
   "scripts": {
     "new:project": "node scripts/new-project.mjs",
     "delete:project": "node scripts/delete-project.mjs",
+    "new:song": "node scripts/new-song.mjs",
     "dev": "next dev",
     "build": "next build",
     "start": "next start",

--- a/scripts/new-song.mjs
+++ b/scripts/new-song.mjs
@@ -1,0 +1,336 @@
+#!/usr/bin/env node
+import fs from 'node:fs/promises'
+import path from 'node:path'
+import prompts from 'prompts'
+
+const root = process.cwd()
+
+// Where the markdown lives
+const contentDir = path.join(root, 'content', 'songs')
+
+// Where song assets live
+const songsDir = path.join(root, 'public', 'songs')
+
+// Reusable example assets (optional)
+const exampleImage = path.join(root, 'public', 'images', 'example.jpg')
+const exampleAudio = path.join(root, 'public', 'audio', 'example.mp3')
+
+function yamlEscape(s) {
+  // keep it simple; wrap in double quotes and escape quotes/newlines
+  const v = String(s ?? '')
+  return `"${v.replace(/\\/g, '\\\\').replace(/"/g, '\\"').replace(/\r?\n/g, '\\n')}"`
+}
+
+function normalizeListFromCSV(input) {
+  const raw = String(input ?? '').trim()
+  if (!raw) return []
+  return raw
+    .split(',')
+    .map((s) => s.trim())
+    .filter(Boolean)
+}
+
+function buildStreamingLinks({
+  spotify,
+  appleMusic,
+  youtube,
+  bandcamp,
+  other,
+}) {
+  const links = []
+  if (spotify) links.push({ label: 'Spotify', url: spotify })
+  if (appleMusic) links.push({ label: 'Apple Music', url: appleMusic })
+  if (youtube) links.push({ label: 'YouTube', url: youtube })
+  if (bandcamp) links.push({ label: 'Bandcamp', url: bandcamp })
+
+  // allow additional "Label=URL, Label=URL"
+  const extra = normalizeListFromCSV(other)
+  for (const item of extra) {
+    const eq = item.indexOf('=')
+    if (eq > 0) {
+      const label = item.slice(0, eq).trim()
+      const url = item.slice(eq + 1).trim()
+      if (label && url) links.push({ label, url })
+    }
+  }
+  return links
+}
+
+function renderYamlListOfStrings(items, indent = '  ') {
+  if (!items.length) return `${indent}[]`
+  return items.map((x) => `${indent}- ${yamlEscape(x)}`).join('\n')
+}
+
+function renderYamlLinks(items, indent = '  ') {
+  if (!items.length) return `${indent}[]`
+  return items
+    .map(
+      (x) =>
+        `${indent}- label: ${yamlEscape(x.label)}\n${indent}  url: ${yamlEscape(x.url)}`,
+    )
+    .join('\n')
+}
+
+const res = await prompts(
+  [
+    {
+      name: 'slug',
+      message: 'Slug (e.g. my-new-song)',
+      type: 'text',
+      validate: (v) => (v ? true : 'Required'),
+    },
+    {
+      name: 'name',
+      message: 'Song name',
+      type: 'text',
+      validate: (v) => (v ? true : 'Required'),
+    },
+    {
+      name: 'releaseDate',
+      message: 'Release date (YYYY, YYYY-MM, or YYYY-MM-DD) (optional)',
+      type: 'text',
+    },
+    {
+      name: 'language',
+      message: 'Language (e.g. en, es, catawba, etc.) (optional)',
+      type: 'text',
+    },
+    {
+      name: 'description',
+      message: 'Short description (optional)',
+      type: 'text',
+    },
+
+    // Streaming links
+    { name: 'spotify', message: 'Spotify URL (optional)', type: 'text' },
+    { name: 'appleMusic', message: 'Apple Music URL (optional)', type: 'text' },
+    { name: 'youtube', message: 'YouTube URL (optional)', type: 'text' },
+    { name: 'bandcamp', message: 'Bandcamp URL (optional)', type: 'text' },
+    {
+      name: 'otherLinks',
+      message:
+        'Other links (optional, CSV of Label=URL, e.g. "SoundCloud=https://..., Site=https://...")',
+      type: 'text',
+    },
+
+    // Audio source mode
+    {
+      name: 'audioMode',
+      message: 'Audio source type',
+      type: 'select',
+      choices: [
+        {
+          title: 'Files in /public/songs/<slug>/ (recommended)',
+          value: 'files',
+        },
+        { title: 'External audio links (no local files)', value: 'links' },
+        { title: 'Both files AND external links', value: 'both' },
+      ],
+      initial: 0,
+    },
+
+    // If files are used: ask for filenames (multiple formats allowed)
+    {
+      name: 'audioFiles',
+      message: 'Audio filenames (CSV) (e.g. "track.mp3, track.wav")',
+      type: (prev) => (prev === 'files' || prev === 'both' ? 'text' : null),
+      initial: 'track.mp3',
+    },
+
+    // If links are used: ask for URLs
+    {
+      name: 'audioLinks',
+      message: 'Audio URLs (CSV) (e.g. "https://...mp3, https://...wav")',
+      type: (_, values) =>
+        values.audioMode === 'links' || values.audioMode === 'both'
+          ? 'text'
+          : null,
+    },
+
+    // Optional cover image
+    {
+      name: 'hasImage',
+      message: 'Include an image?',
+      type: 'toggle',
+      initial: false,
+      active: 'yes',
+      inactive: 'no',
+    },
+    {
+      name: 'imageFiles',
+      message:
+        'Image filenames (CSV) (e.g. "cover.jpg" or "cover.jpg, alt.png")',
+      type: (_, values) => (values.hasImage ? 'text' : null),
+      initial: 'cover.jpg',
+    },
+    {
+      name: 'copyExampleImage',
+      message:
+        'Copy example image into the first image filename (if available)?',
+      type: (_, values) => (values.hasImage ? 'toggle' : null),
+      initial: true,
+      active: 'yes',
+      inactive: 'no',
+    },
+
+    // Lyrics + credits (multiline)
+    { name: 'lyrics', message: 'Lyrics (optional) (paste text)', type: 'text' },
+    {
+      name: 'credits',
+      message: 'Credits (optional) (paste text)',
+      type: 'text',
+    },
+  ],
+  {
+    onCancel: () => {
+      process.exit(1)
+    },
+  },
+)
+
+const {
+  slug,
+  name,
+  releaseDate,
+  streamingLinks,
+  description,
+  lyrics,
+  language,
+  credits,
+  spotify,
+  appleMusic,
+  youtube,
+  bandcamp,
+  otherLinks,
+  audioMode,
+  audioFiles,
+  audioLinks,
+  hasImage,
+  imageFiles,
+  copyExampleImage,
+} = res
+
+if (!slug || !name) process.exit(1)
+
+// Paths
+const mdPath = path.join(contentDir, `${slug}.md`)
+const songAssetDir = path.join(songsDir, slug)
+
+// Parse lists
+const parsedAudioFiles = normalizeListFromCSV(audioFiles)
+const parsedAudioLinks = normalizeListFromCSV(audioLinks)
+const parsedImageFiles = hasImage ? normalizeListFromCSV(imageFiles) : []
+
+// Build streaming links list
+const parsedStreamingLinks = buildStreamingLinks({
+  spotify,
+  appleMusic,
+  youtube,
+  bandcamp,
+  other: otherLinks,
+})
+
+// Frontmatter pieces
+const fm = `---
+type: "song"
+name: ${yamlEscape(name)}
+slug: ${yamlEscape(slug)}
+releaseDate: ${yamlEscape(releaseDate || '')}
+language: ${yamlEscape(language || '')}
+description: ${yamlEscape(description || '')}
+mediaRoot: ${yamlEscape(`/songs/${slug}/`)}
+
+streamingLinks:
+${renderYamlLinks(parsedStreamingLinks)}
+
+audio:
+  files:
+${renderYamlListOfStrings(audioMode === 'files' || audioMode === 'both' ? parsedAudioFiles : [], '    ')}
+  links:
+${renderYamlListOfStrings(audioMode === 'links' || audioMode === 'both' ? parsedAudioLinks : [], '    ')}
+
+images:
+${renderYamlListOfStrings(parsedImageFiles, '  ')}
+---
+
+# ${name}
+`
+
+// Body sections (keep simple and readable)
+const bodyParts = []
+
+if (lyrics && String(lyrics).trim()) {
+  bodyParts.push(`## Lyrics\n\n${String(lyrics).trim()}\n`)
+}
+
+if (credits && String(credits).trim()) {
+  bodyParts.push(`## Credits\n\n${String(credits).trim()}\n`)
+}
+
+const md = fm + (bodyParts.length ? '\n' + bodyParts.join('\n') : '\n')
+
+// Ensure directories
+await fs.mkdir(contentDir, { recursive: true })
+await fs.mkdir(songAssetDir, { recursive: true })
+
+// Write markdown
+await fs.writeFile(mdPath, md, 'utf8')
+
+// Handle copying example assets (best-effort)
+const warnings = []
+
+// Copy example audio into first audio file, if using files and user provided at least one filename
+if (
+  (audioMode === 'files' || audioMode === 'both') &&
+  parsedAudioFiles.length
+) {
+  const target = path.join(songAssetDir, parsedAudioFiles[0])
+
+  // Only copy if target doesn't exist
+  try {
+    await fs.access(target)
+  } catch {
+    try {
+      // If the target extension isn't mp3, we still copy the example mp3 bytes; that can be confusing.
+      // We'll only auto-copy when target ends in .mp3.
+      if (parsedAudioFiles[0].toLowerCase().endsWith('.mp3')) {
+        await fs.copyFile(exampleAudio, target)
+      } else {
+        warnings.push(
+          `Did not copy example audio because first filename is not .mp3 (${parsedAudioFiles[0]}). Place your audio file manually.`,
+        )
+      }
+    } catch (err) {
+      warnings.push(
+        `Could not copy example audio: ${err?.message || String(err)}`,
+      )
+    }
+  }
+}
+
+// Copy example image into first image file, if requested
+if (hasImage && copyExampleImage && parsedImageFiles.length) {
+  const target = path.join(songAssetDir, parsedImageFiles[0])
+  try {
+    await fs.access(target)
+  } catch {
+    try {
+      await fs.copyFile(exampleImage, target)
+    } catch (err) {
+      warnings.push(
+        `Could not copy example image: ${err?.message || String(err)}`,
+      )
+    }
+  }
+}
+
+console.log(`\nCreated:
+- ${path.relative(root, mdPath)}
+- ${path.relative(root, songAssetDir)}/`)
+
+if (warnings.length) {
+  console.log('\nWarnings:')
+  for (const w of warnings) console.log(`- ⚠️ ${w}`)
+}
+
+console.log('')

--- a/src/app/layout.tsx
+++ b/src/app/layout.tsx
@@ -1,36 +1,40 @@
-import type { Metadata } from "next";
-import { Geist, Geist_Mono } from "next/font/google";
-import "./globals.css";
+import type { Metadata } from 'next'
+import { Geist, Geist_Mono } from 'next/font/google'
+import './globals.css'
 
 const geistSans = Geist({
-    variable: "--font-geist-sans",
-    subsets: ["latin"],
-});
+  variable: '--font-geist-sans',
+  subsets: ['latin'],
+})
 
 const geistMono = Geist_Mono({
-    variable: "--font-geist-mono",
-    subsets: ["latin"],
-});
+  variable: '--font-geist-mono',
+  subsets: ['latin'],
+})
 
 export const metadata: Metadata = {
-    title: "DeLesslin George-Warren",
-    description: "Code, art, and advocacy by DeLesslin",
-    // icons: {
-    //     icon: "/favicon.ico",
-    // },
-};
+  title: 'DeLesslin George-Warren',
+  description: 'Code, art, and advocacy by DeLesslin',
+}
 
 export default function RootLayout({
-    children,
-}: Readonly<{
-    children: React.ReactNode;
-}>) {
-    return (
-        <html lang="en">
-            <head>
-                <link rel="icon" href="/images/favicon.ico" sizes="any" />
-            </head>
-            <body className={`${geistSans.variable} ${geistMono.variable} antialiased`}>{children}</body>
-        </html>
-    );
+  children,
+}: {
+  children: React.ReactNode
+}) {
+  return (
+    <html lang='en' className='h-full overflow-hidden overscroll-none'>
+      <head>
+        <link rel='icon' href='/images/favicon.ico' sizes='any' />
+      </head>
+      <body
+        className={`${geistSans.variable} ${geistMono.variable} antialiased h-full overflow-hidden`}
+      >
+        {/* single scroll surface */}
+        <div className='h-full overflow-y-auto overscroll-none [-webkit-overflow-scrolling:touch]'>
+          {children}
+        </div>
+      </body>
+    </html>
+  )
 }

--- a/src/components/Contact.tsx
+++ b/src/components/Contact.tsx
@@ -3,7 +3,7 @@ const Contact = () => {
   const color = '#333'
   return (
     <section
-      className='border-l-16 min-h-[500px] flex mb-12'
+      className='border-l-16 min-h-[500px] flex'
       style={{ borderColor: color }}
     >
       <div className='mx-4 flex-1 p-4' style={{ backgroundColor: color }}>

--- a/src/components/ContactForm.tsx
+++ b/src/components/ContactForm.tsx
@@ -68,7 +68,7 @@ export default function ContactForm() {
   }
 
   return (
-    <form onSubmit={onSubmit} className='space-y-4 max-w-[700]'>
+    <form onSubmit={onSubmit} className='space-y-4 max-w-[700] min-h-[50vh]'>
       <label className='block text-white'>
         <span>Name</span>
         <input
@@ -113,7 +113,7 @@ export default function ContactForm() {
         <button
           type='submit'
           disabled={status === 'sending'}
-          className='border px-4 py-2 text-white'
+          className='border px-4 py-2 text-white cursor-pointer'
         >
           {status === 'sending' ? 'Sending...' : 'Send'}
         </button>

--- a/src/components/Project.tsx
+++ b/src/components/Project.tsx
@@ -7,10 +7,10 @@ const Project = ({ p, color }: { p: ProjectType; color: string }) => {
   return (
     <article
       key={p.slug}
-      className={`border-l-16 px-4 pb-12 lg:pb-0 lg:mb-8 flex min-h-[500px] flex-col gap-6 lg:flex-row lg:gap-5`}
+      className={`border-l-16 px-4 pb-12 lg:pb-0 lg:mb-8 flex min-h-[90vh] flex-col gap-6 lg:flex-row lg:gap-5`}
       style={{ borderColor: color }}
     >
-      <div className='w-full min-w-0 lg:flex-none lg:w-[700px] lg:max-w-[700px]'>
+      <div className='w-full h-full min-w-0 lg:flex-none lg:w-[700px] lg:max-w-[700px]'>
         <Images images={p.images} alt={p.title} />
       </div>
       <div className='flex w-full min-w-0 flex-col gap-7'>
@@ -75,7 +75,7 @@ const Images = ({
   const [active, setActive] = useState(0)
 
   return (
-    <div className='flex h-[420px] w-full gap-3 lg:h-[700px]'>
+    <div className='flex h-[30vh] w-full gap-3 lg:h-[90vh]'>
       {images &&
         images.length > 0 &&
         images.map((img, i) => {


### PR DESCRIPTION
# Add song management functionality

### TL;DR

Added a new song creation script and improved layout styling for better mobile experience.

### What changed?

- Created a new script (`scripts/new-song.mjs`) to generate song content files
- Added a new npm command `new:song` to run the script
- Added a sample song "Fake It" with basic metadata and audio file
- Fixed layout issues by making the page properly fill the viewport height
- Improved scrolling behavior with `overscroll-none` and other CSS adjustments
- Adjusted component heights to use viewport-relative units (vh)
- Enhanced the contact form with better spacing and cursor styling

### How to test?

1. Run `npm run new:song` to create a new song
2. Follow the interactive prompts to set up song details
3. Check the generated markdown file in `content/songs/`
4. Verify the layout improvements on both desktop and mobile devices

### Why make this change?

This change enables easier management of song content through a standardized creation process, similar to the existing project management scripts. The layout improvements address scrolling issues and ensure content displays properly across different devices and screen sizes.