### PR TITLE
Create unstyled /links/page.tsx

### DIFF
--- a/src/app/links/page.tsx
+++ b/src/app/links/page.tsx
@@ -1,0 +1,31 @@
+import { getAllLinks } from "@/lib/linkStore";
+
+export const runtime = "nodejs";
+
+export default async function LinksPage() {
+    const links = await getAllLinks();
+
+    const publicLinks = links.filter((l) => l.public).sort((a, b) => a.slug.localeCompare(b.slug));
+
+    return (
+        <main>
+            <h1>Public Links</h1>
+
+            <ul>
+                {publicLinks.map((link) => (
+                    <li key={link.slug}>
+                        <h2>
+                            <a href={`/${link.slug}`}>{link.title ?? link.slug}</a>
+                        </h2>
+
+                        {link.description && <p>{link.description}</p>}
+
+                        <p>
+                            <a href={`/${link.slug}.png`}>QR</a>
+                        </p>
+                    </li>
+                ))}
+            </ul>
+        </main>
+    );
+}


### PR DESCRIPTION
### TL;DR

Added a new `/links` page that displays all public links with QR code access.

### What changed?

Created a new `LinksPage` component at `/src/app/links/page.tsx` that:
- Fetches all links using `getAllLinks()` from the link store
- Filters and displays only public links, sorted alphabetically by slug
- Shows each link's title (or slug if no title), optional description, and a QR code link
- Uses Node.js runtime for server-side rendering

### How to test?

1. Navigate to `/links` in your browser
2. Verify that only public links are displayed
3. Check that links are sorted alphabetically by slug
4. Confirm that clicking on link titles navigates to `/{slug}`
5. Test that QR links point to `/{slug}.png`
6. Verify descriptions appear when present

### Why make this change?

This provides a centralized directory page where users can browse all publicly available links, making link discovery easier and providing quick access to QR codes for sharing.