### PR TITLE
IDK fixing qr code? maybe

### DIFF
--- a/src/app/qr/[slug]/route.ts
+++ b/src/app/qr/[slug]/route.ts
@@ -130,7 +130,7 @@ export async function GET(req: Request, ctx: Ctx) {
     }
 
     const slugRecord = await getLinkForSlug(slug);
-    if (!slugRecord || slugRecord.url) {
+    if (!slugRecord || !slugRecord.url) {
         return NextResponse.redirect(fallbackUrl(slug), 302);
     }
 


### PR DESCRIPTION
### TL;DR

Fixed QR code redirect logic to properly handle records with missing URLs

### What changed?

Corrected the condition in the QR code route handler from `!slugRecord || slugRecord.url` to `!slugRecord || !slugRecord.url`. This ensures that when a slug record exists but has no URL, it will redirect to the fallback URL instead of proceeding with an empty URL.

### How to test?

1. Create a QR code slug record in the database without a URL value
2. Access the QR endpoint with that slug: `/qr/[slug]`
3. Verify that it redirects to the fallback URL instead of attempting to redirect to an empty/null URL
4. Test with a valid slug that has a URL to ensure normal functionality still works

### Why make this change?

The previous logic had a bug where records with empty or null URLs would not trigger the fallback redirect, potentially causing issues when trying to redirect users to invalid destinations. This fix ensures proper fallback behavior for incomplete records.