### PR TITLE
Fix /links z-index stacking issue

### DIFF
--- a/README.md
+++ b/README.md
@@ -38,7 +38,7 @@ Personal portfolio and utility website
   - [x] Why "(CSV)" in audio filename and image filenames?
   - [x] What is the "Copy example image into first filename"? Probably can remove
 - [ ] Handle NOT FOUND in /music/...
-- [ ] separate sketch from P5Canvas
+- [x] separate sketch from P5Canvas
 - [ ] Add music visualizer sketch
 - [ ] Control music visualizer and play/stop buttons
 - [ ] Style music control

--- a/src/app/links/page.tsx
+++ b/src/app/links/page.tsx
@@ -36,7 +36,7 @@ export default async function LinksPage() {
       <div className='absolute inset-0'>
         <BoidCanvas />
       </div>
-      <section className='flex flex-col justify-center lg:px-72 pt-32 bg-white'>
+      <section className='z-99 relative flex flex-col justify-center lg:px-72 pt-32 bg-white'>
         <div className='py-12'>
           <h1 className='text-center text-7xl font-black'>Links</h1>
           <h2 className='italic text-center'>look at all my things</h2>


### PR DESCRIPTION
### TL;DR

Separated sketch from P5Canvas component and fixed z-index layering issue on links page

### What changed?

- Marked the "separate sketch from P5Canvas" task as completed in the README checklist
- Added `z-99 relative` classes to the links page section to ensure proper layering above the BoidCanvas background

### How to test?

1. Navigate to the `/links` page
2. Verify that the links content appears above the BoidCanvas background animation
3. Confirm that the text and links are properly visible and interactive

### Why make this change?

The z-index fix ensures that the links page content is properly layered above the background canvas animation, preventing any potential interaction or visibility issues. Completing the P5Canvas separation task indicates improved code organization and component separation.