### PR TITLE
Add MusicPlayer

### DIFF
--- a/README.md
+++ b/README.md
@@ -21,7 +21,6 @@ Personal portfolio and utility website
 
 ## TODO
 
-- [x] Adapt design based on screen size
 - [ ] Filter brand search params
 - [ ] How to order projects?
 - [ ] Add other art projects
@@ -31,14 +30,7 @@ Personal portfolio and utility website
 - [ ] Checks for project: is the slug valid? does the folder exist in public > projects? do all the referenced images and audio exist?
 - [ ] Animate links
 - [ ] Add animation to music player: https://editor.p5js.org/js6450/sketches/XYnHHUIP7
-- [x] Further refine the new-song.mjs script
-  - [x] Remove Audio source type (we can assume it will be a local file)
-  - [x] Assume one audio file
-  - [x] Assume one image file
-  - [x] Why "(CSV)" in audio filename and image filenames?
-  - [x] What is the "Copy example image into first filename"? Probably can remove
 - [ ] Handle NOT FOUND in /music/...
-- [x] separate sketch from P5Canvas
 - [ ] Add music visualizer sketch
 - [ ] Control music visualizer and play/stop buttons
 - [ ] Style music control
@@ -46,3 +38,14 @@ Personal portfolio and utility website
 - [ ] For now: have a IFrame for distrokid
 - [ ] Add links (e.g. music and contact) to main portfolio page
 - [ ] Cleanup console.logs
+- [ ] Add light version of MotionTitle (default: dark)
+
+### COMPLETE
+- [x] Adapt design based on screen size
+- [x] Further refine the new-song.mjs script
+  - [x] Remove Audio source type (we can assume it will be a local file)
+  - [x] Assume one audio file
+  - [x] Assume one image file
+  - [x] Why "(CSV)" in audio filename and image filenames?
+  - [x] What is the "Copy example image into first filename"? Probably can remove
+- [x] separate sketch from P5Canvas

--- a/package-lock.json
+++ b/package-lock.json
@@ -8,6 +8,7 @@
       "name": "portfolio",
       "version": "0.1.0",
       "dependencies": {
+        "@deemlol/next-icons": "^0.1.9",
         "@p5-wrapper/react": "^4.4.2",
         "@radix-ui/react-slot": "^1.2.2",
         "@react-email/components": "^1.0.3",
@@ -345,6 +346,15 @@
       "version": "0.0.2",
       "resolved": "https://registry.npmjs.org/@davepagurek/bezier-path/-/bezier-path-0.0.2.tgz",
       "integrity": "sha512-4L9ddgzZc9DRGyl1RrS3z5nwnVJoyjsAelVG4X1jh4tVxryEHr4H9QavhxW/my6Rn3669Qz6mhv8gd5O/WeFTA=="
+    },
+    "node_modules/@deemlol/next-icons": {
+      "version": "0.1.9",
+      "resolved": "https://registry.npmjs.org/@deemlol/next-icons/-/next-icons-0.1.9.tgz",
+      "integrity": "sha512-TgKjPAyNTmmpmYSvRX6T0ZkqdV96vo7iEkiCEhQ8ZpBXrKvBokRn3wmuoFv44st6hI0vw2SVsF3TXrKe+s3MUQ==",
+      "license": "MIT",
+      "peerDependencies": {
+        "react": "^19.0.0"
+      }
     },
     "node_modules/@emnapi/core": {
       "version": "1.4.3",

--- a/package.json
+++ b/package.json
@@ -13,6 +13,7 @@
     "lint": "eslint ."
   },
   "dependencies": {
+    "@deemlol/next-icons": "^0.1.9",
     "@p5-wrapper/react": "^4.4.2",
     "@radix-ui/react-slot": "^1.2.2",
     "@react-email/components": "^1.0.3",

--- a/src/app/music/[slug]/page.tsx
+++ b/src/app/music/[slug]/page.tsx
@@ -1,6 +1,7 @@
+import MotionTitle from '@/components/MotionTitle'
+import MusicPlayer from '@/components/MusicPlayer'
 import { getSongBySlug } from '@/lib/songs'
 import { notFound } from 'next/navigation'
-
 type Props = {
   params: Promise<{ slug: string }>
 }
@@ -14,48 +15,9 @@ export default async function Song({ params }: Props) {
   }
 
   return (
-    <div>
-      <h1>Debug View</h1>
-
-      {Object.entries(song).map(([key, value]) => {
-        return (
-          <div key={key} style={{ marginBottom: '2rem' }}>
-            <h3>{key}</h3>
-
-            {renderValue(key, value)}
-          </div>
-        )
-      })}
-    </div>
+    <main>
+      <MotionTitle />
+      <MusicPlayer song={song} />
+    </main>
   )
-}
-
-function renderValue(key: string, value: unknown) {
-  if (value == null) {
-    return <p>null</p>
-  }
-
-  if (key === 'contentHtml' && typeof value === 'string') {
-    return <div dangerouslySetInnerHTML={{ __html: value }} />
-  }
-
-  if (Array.isArray(value)) {
-    return (
-      <ul>
-        {value.map((item, i) => (
-          <li key={i}>
-            {typeof item === 'object'
-              ? JSON.stringify(item, null, 2)
-              : String(item)}
-          </li>
-        ))}
-      </ul>
-    )
-  }
-
-  if (typeof value === 'object') {
-    return <pre>{JSON.stringify(value, null, 2)}</pre>
-  }
-
-  return <p>{String(value)}</p>
 }

--- a/src/components/MusicPlayer.tsx
+++ b/src/components/MusicPlayer.tsx
@@ -1,0 +1,94 @@
+'use client'
+
+import { Song } from '@/lib/songs'
+import { Pause, Play } from '@deemlol/next-icons'
+import type p5 from 'p5'
+import { useCallback, useEffect, useRef, useState } from 'react'
+import P5Canvas from './P5Canvas'
+import visualizerSketch from './visualizerSketch'
+export default function MusicSection({ song }: { song: Song }) {
+  const audioRef = useRef<HTMLAudioElement>(null)
+  const audioContextRef = useRef<AudioContext | null>(null)
+  const analyserRef = useRef<AnalyserNode | null>(null)
+  const [isPlaying, setIsPlaying] = useState(false)
+
+  useEffect(() => {
+    const audio = audioRef.current!
+    const context = new AudioContext()
+    const source = context.createMediaElementSource(audio)
+    const analyser = context.createAnalyser()
+
+    analyser.fftSize = 512
+
+    source.connect(analyser)
+    analyser.connect(context.destination)
+
+    audioContextRef.current = context
+    analyserRef.current = analyser
+
+    return () => {
+      context.close()
+    }
+  }, [])
+
+  const toggle = async () => {
+    const audio = audioRef.current!
+    const context = audioContextRef.current
+
+    if (!context) return
+
+    // Resume context if suspended (browser autoplay policy)
+    if (context.state === 'suspended') {
+      await context.resume()
+    }
+
+    if (audio.paused) {
+      await audio.play()
+      setIsPlaying(true)
+    } else {
+      audio.pause()
+      setIsPlaying(false)
+    }
+  }
+
+  const sketch = useCallback((p: p5) => visualizerSketch(p, analyserRef), [])
+  const src = song.audioFiles[0]
+  const img = song.images[0]
+  console.log(img)
+  return (
+    <div className='h-full w-full relative'>
+      <div className='flex absolute bottom-0 xl:bottom-10 xl:right-10 w-full xl:w-150 h-25 bg-white'>
+        <button
+          onClick={toggle}
+          className='relative w-25 h-full grid place-items-center overflow-hidden'
+        >
+          {/* Background layer */}
+          <div
+            className='absolute inset-0 bg-cover bg-center'
+            style={{ backgroundImage: `url(${img})`, opacity: 0.5 }}
+          />
+
+          {/* Optional dark overlay for better contrast */}
+          <div className='absolute inset-0 bg-black/30' />
+
+          {/* Foreground content */}
+          <div className='relative z-10'>
+            {isPlaying ? (
+              <Pause size={36} color='#FFFFFF' />
+            ) : (
+              <Play size={36} color='#FFFFFF' />
+            )}
+          </div>
+        </button>
+        <div className='relative py-2 px-4 self-center'>
+          <h1 className='font-black text-3xl'>{song.name}</h1>
+          <h2 className='italic'>{song.description}</h2>
+        </div>
+      </div>
+
+      <audio ref={audioRef} src={src} />
+
+      <P5Canvas sketch={sketch} />
+    </div>
+  )
+}

--- a/src/components/P5Canvas.tsx
+++ b/src/components/P5Canvas.tsx
@@ -4,7 +4,6 @@ import p5 from 'p5'
 import { useEffect, useRef } from 'react'
 
 type Sketch = (p: p5) => void
-
 export default function P5Canvas({ sketch }: { sketch: Sketch }) {
   const canvasRef = useRef<HTMLDivElement>(null)
   const p5Ref = useRef<p5>(null)

--- a/src/components/visualizerSketch.ts
+++ b/src/components/visualizerSketch.ts
@@ -1,0 +1,56 @@
+import type p5 from 'p5'
+import type { MutableRefObject } from 'react'
+
+function asAnalyserArray(arr: Uint8Array): Uint8Array<ArrayBuffer> {
+  return arr as unknown as Uint8Array<ArrayBuffer>
+}
+
+export default function visualizerSketch(
+  p: p5,
+  analyserRef: MutableRefObject<AnalyserNode | null>,
+) {
+  let dataArray: Uint8Array | null = null
+  let waveformArray: Uint8Array | null = null
+
+  p.setup = () => {
+    p.createCanvas(p.windowWidth, p.windowHeight)
+    p.noFill()
+  }
+
+  p.draw = () => {
+    p.background(0, 0, 0, 20)
+
+    const analyser = analyserRef.current
+    if (!analyser) return
+
+    if (!dataArray || !waveformArray) {
+      dataArray = new Uint8Array(analyser.frequencyBinCount)
+      waveformArray = new Uint8Array(analyser.fftSize)
+    }
+
+    analyser.getByteFrequencyData(asAnalyserArray(dataArray))
+    analyser.getByteTimeDomainData(asAnalyserArray(waveformArray))
+
+    // ----- Spectrum -----
+    p.stroke(180, 100, 255)
+    for (let i = 0; i < dataArray.length; i++) {
+      const x = p.map(i, 0, dataArray.length, 0, p.width)
+      const h = p.map(dataArray[i], 0, 255, 0, p.height / 2)
+      p.line(x, p.height, x, p.height - h)
+    }
+
+    // ----- Waveform -----
+    p.stroke(255)
+    p.beginShape()
+    for (let i = 0; i < waveformArray.length; i++) {
+      const x = p.map(i, 0, waveformArray.length, 0, p.width)
+      const y = p.map(waveformArray[i], 0, 255, 0, p.height)
+      p.vertex(x, y)
+    }
+    p.endShape()
+  }
+
+  p.windowResized = () => {
+    p.resizeCanvas(p.windowWidth, p.windowHeight)
+  }
+}


### PR DESCRIPTION
### TL;DR

Added a music player component with audio visualization for individual song pages

### What changed?

- Added `@deemlol/next-icons` dependency for play/pause icons
- Created `MusicPlayer` component that handles audio playback with Web Audio API integration
- Created `visualizerSketch` component that renders real-time frequency spectrum and waveform visualization using p5.js
- Replaced debug view in `/music/[slug]` page with the new music player interface
- Reorganized TODO list by moving completed items to a separate "COMPLETE" section

### How to test?

1. Navigate to any music page (e.g. `/music/[song-slug]`)
2. Click the play/pause button to control audio playback
3. Observe the real-time audio visualization while music is playing
4. Verify the player shows song name, description, and album artwork

### Why make this change?

This transforms the music pages from a basic debug view into a functional music player with visual feedback, providing users with an engaging way to listen to tracks while viewing dynamic audio visualizations.