### PR TITLE
Add bandcamp section to /music/[song]

### DIFF
--- a/README.md
+++ b/README.md
@@ -39,7 +39,7 @@ Personal portfolio and utility website
 - [ ] Add links (e.g. music and contact) to main portfolio page
 - [ ] Cleanup console.logs
 - [ ] Add light version of MotionTitle (default: dark)
-
+- [ ] handle no bandcamp
 ### COMPLETE
 - [x] Adapt design based on screen size
 - [x] Further refine the new-song.mjs script

--- a/src/app/music/[slug]/page.tsx
+++ b/src/app/music/[slug]/page.tsx
@@ -1,6 +1,8 @@
 import MotionTitle from '@/components/MotionTitle'
 import MusicPlayer from '@/components/MusicPlayer'
+import colors from '@/lib/colors'
 import { getSongBySlug } from '@/lib/songs'
+import Image from 'next/image'
 import { notFound } from 'next/navigation'
 type Props = {
   params: Promise<{ slug: string }>
@@ -13,11 +15,34 @@ export default async function Song({ params }: Props) {
   if (!song) {
     notFound()
   }
-
+  console.log(song.streamingLinks)
+  const bandcamp = song.streamingLinks.filter(
+    (link) => link.label.toLowerCase() === 'bandcamp',
+  )[0]
+  console.log(bandcamp)
   return (
     <main>
       <MotionTitle />
       <MusicPlayer song={song} />
+      <section className='flex' style={{ backgroundColor: colors[2] }}>
+        <Image
+          src={song.images[0]}
+          height='500'
+          width='500'
+          alt='Fake it album art feature a psychedelic pug'
+        />
+        <div className='flex-1 grid place-items-center'>
+          <div>
+            <h1 className='italic text-6xl'>Want to support my music?</h1>
+            <h2>The best way is to buy this track on BandCamp!</h2>
+            <button className='h-18 w-full bg-amber-500 flex border-l-4 border-amber-500'>
+              <div className=' flex-1 '>
+                <h3 className='flex-1'>Buy this track on BandCamp</h3>
+              </div>
+            </button>
+          </div>
+        </div>
+      </section>
     </main>
   )
 }


### PR DESCRIPTION
### TL;DR

Added a support section to individual song pages encouraging users to purchase tracks on BandCamp

### What changed?

- Added a new section below the music player on song pages with album artwork and a call-to-action
- Implemented logic to extract BandCamp links from song streaming links
- Added TODO item to handle cases where BandCamp links are not available
- Included styling with background colors and a prominent purchase button

### How to test?

1. Navigate to any individual song page (e.g. `/music/[slug]`)
2. Verify the new support section appears below the music player
3. Check that the album artwork displays correctly
4. Confirm the BandCamp purchase button is visible and styled appropriately

### Why make this change?

To provide a direct monetization path for music by prominently featuring BandCamp purchase options on individual song pages, making it easier for listeners to support the artist financially.