### PR TITLE
Fix 'any' ts errors

### DIFF
--- a/src/components/P5Canvas.tsx
+++ b/src/components/P5Canvas.tsx
@@ -20,7 +20,7 @@ export default function P5Canvas({ sketch }: { sketch: Sketch }) {
     return () => {
       p5Ref.current?.remove() // Clean up
     }
-  }, [])
+  }, [sketch])
 
   return <div ref={canvasRef} className='w-full h-full' />
 }

--- a/src/lib/songs.ts
+++ b/src/lib/songs.ts
@@ -92,13 +92,13 @@ function filterStreamingLinks(arr: unknown): StreamingLink[] {
   if (!Array.isArray(arr)) return []
 
   return arr
-    .filter(
-      (entry): entry is StreamingLink =>
-        typeof entry === 'object' &&
-        entry !== null &&
-        typeof (entry as any).label === 'string' &&
-        typeof (entry as any).url === 'string',
-    )
+    .filter((entry): entry is StreamingLink => {
+      if (typeof entry !== 'object' || entry === null) return false
+
+      const maybe = entry as Record<string, unknown>
+
+      return typeof maybe.label === 'string' && typeof maybe.url === 'string'
+    })
     .map((entry) => ({
       label: entry.label,
       url: entry.url,
@@ -111,8 +111,16 @@ export async function getSongBySlug(slug: string): Promise<Song | null> {
 
   try {
     raw = await fs.readFile(filePath, 'utf8')
-  } catch (e: any) {
-    if (e.code === 'ENOENT') return null
+  } catch (e: unknown) {
+    if (
+      typeof e === 'object' &&
+      e !== null &&
+      'code' in e &&
+      (e as { code?: string }).code === 'ENOENT'
+    ) {
+      return null
+    }
+
     throw e
   }
 


### PR DESCRIPTION
### TL;DR

Fixed P5Canvas re-rendering and improved TypeScript type safety with proper unknown type handling

### What changed?

- Updated P5Canvas useEffect dependency array to include `sketch` parameter, ensuring the canvas re-renders when the sketch changes
- Refactored `filterStreamingLinks` function to use proper TypeScript type guards with explicit type checking
- Enhanced error handling in `getSongBySlug` to safely check error properties without using `any` type

### How to test?

- Verify that P5Canvas components properly update when switching between different sketches
- Test that streaming links are correctly filtered and validated
- Confirm that file not found errors are handled gracefully when loading songs by slug

### Why make this change?

The P5Canvas component wasn't responding to sketch changes due to missing dependency, and the codebase had unsafe type assertions using `any` that could lead to runtime errors. These changes improve both functionality and type safety.