### PR TITLE
Create spaceholder for musicVisualizer

### DIFF
--- a/README.md
+++ b/README.md
@@ -40,6 +40,7 @@ Personal portfolio and utility website
 - [ ] Cleanup console.logs
 - [ ] Add light version of MotionTitle (default: dark)
 - [ ] handle no bandcamp
+- [ ] Add design for fallback canvas in /music/[slug]
 ### COMPLETE
 - [x] Adapt design based on screen size
 - [x] Further refine the new-song.mjs script

--- a/src/app/music/[slug]/page.tsx
+++ b/src/app/music/[slug]/page.tsx
@@ -23,7 +23,9 @@ export default async function Song({ params }: Props) {
   return (
     <main>
       <MotionTitle />
-      <MusicPlayer song={song} />
+      <section className='h-screen w-screen'>
+        <MusicPlayer song={song} />
+      </section>
       <section className='flex' style={{ backgroundColor: colors[2] }}>
         <Image
           src={song.images[0]}


### PR DESCRIPTION
### TL;DR

Wrapped the MusicPlayer component in a full-screen section container and added a new TODO item for fallback canvas design.

### What changed?

- Added a new TODO item to the README for designing a fallback canvas in the `/music/[slug]` route
- Wrapped the `MusicPlayer` component in a `<section>` element with `h-screen w-screen` classes to make it occupy the full viewport

### How to test?

1. Navigate to any music page using the `/music/[slug]` route
2. Verify that the MusicPlayer component now takes up the full screen height and width
3. Check that the layout renders correctly across different screen sizes

### Why make this change?

The MusicPlayer component needed proper full-screen styling to improve the user experience and visual presentation of the music player interface.