### PR TITLE
Finish /music/[slug] component

### DIFF
--- a/.claude/settings.local.json
+++ b/.claude/settings.local.json
@@ -1,0 +1,7 @@
+{
+  "permissions": {
+    "allow": [
+      "WebFetch(domain:distrokid.com)"
+    ]
+  }
+}

--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -1,0 +1,3 @@
+{
+    "postman.settings.dotenv-detection-notification-visibility": false
+}

--- a/next.config.ts
+++ b/next.config.ts
@@ -1,7 +1,11 @@
 import type { NextConfig } from "next";
 
 const nextConfig: NextConfig = {
-  /* config options here */
+  images: {
+    remotePatterns: [
+      { protocol: 'https', hostname: 'distrokid.imgix.net' },
+    ],
+  },
 };
 
 export default nextConfig;

--- a/package-lock.json
+++ b/package-lock.json
@@ -13,6 +13,7 @@
         "@radix-ui/react-slot": "^1.2.2",
         "@react-email/components": "^1.0.3",
         "@react-email/render": "^2.0.1",
+        "cheerio": "^1.2.0",
         "class-variance-authority": "^0.7.1",
         "clsx": "^2.1.1",
         "framer-motion": "^12.23.24",
@@ -35,6 +36,7 @@
       },
       "devDependencies": {
         "@tailwindcss/postcss": "^4",
+        "@types/cheerio": "^0.22.35",
         "@types/node": "^20",
         "@types/p5": "^1.7.6",
         "@types/qrcode": "^1.5.6",
@@ -2021,6 +2023,16 @@
         "tslib": "^2.4.0"
       }
     },
+    "node_modules/@types/cheerio": {
+      "version": "0.22.35",
+      "resolved": "https://registry.npmjs.org/@types/cheerio/-/cheerio-0.22.35.tgz",
+      "integrity": "sha512-yD57BchKRvTV+JD53UZ6PD8KWY5g5rvvMLRnZR3EQBCZXiDT/HR+pKpMzFGlWNhFrXlo7VPZXtKvIEwZkAWOIA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/node": "*"
+      }
+    },
     "node_modules/@types/debug": {
       "version": "4.1.12",
       "resolved": "https://registry.npmjs.org/@types/debug/-/debug-4.1.12.tgz",
@@ -2979,6 +2991,12 @@
         "node": "*"
       }
     },
+    "node_modules/boolbase": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/boolbase/-/boolbase-1.0.0.tgz",
+      "integrity": "sha512-JZOSA7Mo9sNGB8+UjSgzdLtokWAky1zbztM3WRLCbZ70/3cTANmQmOdR7y2g+J0e2WXywy1yS468tY+IruqEww==",
+      "license": "ISC"
+    },
     "node_modules/brace-expansion": {
       "version": "1.1.12",
       "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.12.tgz",
@@ -3182,6 +3200,79 @@
         "url": "https://github.com/sponsors/wooorm"
       }
     },
+    "node_modules/cheerio": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/cheerio/-/cheerio-1.2.0.tgz",
+      "integrity": "sha512-WDrybc/gKFpTYQutKIK6UvfcuxijIZfMfXaYm8NMsPQxSYvf+13fXUJ4rztGGbJcBQ/GF55gvrZ0Bc0bj/mqvg==",
+      "license": "MIT",
+      "dependencies": {
+        "cheerio-select": "^2.1.0",
+        "dom-serializer": "^2.0.0",
+        "domhandler": "^5.0.3",
+        "domutils": "^3.2.2",
+        "encoding-sniffer": "^0.2.1",
+        "htmlparser2": "^10.1.0",
+        "parse5": "^7.3.0",
+        "parse5-htmlparser2-tree-adapter": "^7.1.0",
+        "parse5-parser-stream": "^7.1.2",
+        "undici": "^7.19.0",
+        "whatwg-mimetype": "^4.0.0"
+      },
+      "engines": {
+        "node": ">=20.18.1"
+      },
+      "funding": {
+        "url": "https://github.com/cheeriojs/cheerio?sponsor=1"
+      }
+    },
+    "node_modules/cheerio-select": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/cheerio-select/-/cheerio-select-2.1.0.tgz",
+      "integrity": "sha512-9v9kG0LvzrlcungtnJtpGNxY+fzECQKhK4EGJX2vByejiMX84MFNQw4UxPJl3bFbTMw+Dfs37XaIkCwTZfLh4g==",
+      "license": "BSD-2-Clause",
+      "dependencies": {
+        "boolbase": "^1.0.0",
+        "css-select": "^5.1.0",
+        "css-what": "^6.1.0",
+        "domelementtype": "^2.3.0",
+        "domhandler": "^5.0.3",
+        "domutils": "^3.0.1"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/fb55"
+      }
+    },
+    "node_modules/cheerio/node_modules/entities": {
+      "version": "7.0.1",
+      "resolved": "https://registry.npmjs.org/entities/-/entities-7.0.1.tgz",
+      "integrity": "sha512-TWrgLOFUQTH994YUyl1yT4uyavY5nNB5muff+RtWaqNVCAK408b5ZnnbNAUEWLTCpum9w6arT70i1XdQ4UeOPA==",
+      "license": "BSD-2-Clause",
+      "engines": {
+        "node": ">=0.12"
+      },
+      "funding": {
+        "url": "https://github.com/fb55/entities?sponsor=1"
+      }
+    },
+    "node_modules/cheerio/node_modules/htmlparser2": {
+      "version": "10.1.0",
+      "resolved": "https://registry.npmjs.org/htmlparser2/-/htmlparser2-10.1.0.tgz",
+      "integrity": "sha512-VTZkM9GWRAtEpveh7MSF6SjjrpNVNNVJfFup7xTY3UpFtm67foy9HDVXneLtFVt4pMz5kZtgNcvCniNFb1hlEQ==",
+      "funding": [
+        "https://github.com/fb55/htmlparser2?sponsor=1",
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/fb55"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "domelementtype": "^2.3.0",
+        "domhandler": "^5.0.3",
+        "domutils": "^3.2.2",
+        "entities": "^7.0.1"
+      }
+    },
     "node_modules/class-variance-authority": {
       "version": "0.7.1",
       "resolved": "https://registry.npmjs.org/class-variance-authority/-/class-variance-authority-0.7.1.tgz",
@@ -3334,6 +3425,34 @@
       },
       "engines": {
         "node": ">= 8"
+      }
+    },
+    "node_modules/css-select": {
+      "version": "5.2.2",
+      "resolved": "https://registry.npmjs.org/css-select/-/css-select-5.2.2.tgz",
+      "integrity": "sha512-TizTzUddG/xYLA3NXodFM0fSbNizXjOKhqiQQwvhlspadZokn1KDy0NZFS0wuEubIYAV5/c1/lAr0TaaFXEXzw==",
+      "license": "BSD-2-Clause",
+      "dependencies": {
+        "boolbase": "^1.0.0",
+        "css-what": "^6.1.0",
+        "domhandler": "^5.0.2",
+        "domutils": "^3.0.1",
+        "nth-check": "^2.0.1"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/fb55"
+      }
+    },
+    "node_modules/css-what": {
+      "version": "6.2.2",
+      "resolved": "https://registry.npmjs.org/css-what/-/css-what-6.2.2.tgz",
+      "integrity": "sha512-u/O3vwbptzhMs3L1fQE82ZSLHQQfto5gyZzwteVIEyeaY5Fc7R4dapF/BvRoSYFeqfBk4m0V1Vafq5Pjv25wvA==",
+      "license": "BSD-2-Clause",
+      "engines": {
+        "node": ">= 6"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/fb55"
       }
     },
     "node_modules/csstype": {
@@ -3639,6 +3758,19 @@
       "version": "9.2.2",
       "resolved": "https://registry.npmjs.org/emoji-regex/-/emoji-regex-9.2.2.tgz",
       "integrity": "sha512-L18DaJsXSUk2+42pv8mLs5jJT2hqFkFE4j21wOmgbUqsZ2hL72NsUU785g9RXgo3s0ZNgVl42TiHp3ZtOv/Vyg=="
+    },
+    "node_modules/encoding-sniffer": {
+      "version": "0.2.1",
+      "resolved": "https://registry.npmjs.org/encoding-sniffer/-/encoding-sniffer-0.2.1.tgz",
+      "integrity": "sha512-5gvq20T6vfpekVtqrYQsSCFZ1wEg5+wW0/QaZMWkFr6BqD3NfKs0rLCx4rrVlSWJeZb5NBJgVLswK/w2MWU+Gw==",
+      "license": "MIT",
+      "dependencies": {
+        "iconv-lite": "^0.6.3",
+        "whatwg-encoding": "^3.1.1"
+      },
+      "funding": {
+        "url": "https://github.com/fb55/encoding-sniffer?sponsor=1"
+      }
     },
     "node_modules/enhanced-resolve": {
       "version": "5.18.1",
@@ -5148,6 +5280,18 @@
       "integrity": "sha512-KIToAzf8zwWvacgnRwJp63ase26o24AuNUlfNVJ5YZAFmdGhsJpmFClxXPuk9rv1FMI4lnc8zLSqgZPEZMrW4g==",
       "dependencies": {
         "@babel/runtime": "^7.5.5"
+      }
+    },
+    "node_modules/iconv-lite": {
+      "version": "0.6.3",
+      "resolved": "https://registry.npmjs.org/iconv-lite/-/iconv-lite-0.6.3.tgz",
+      "integrity": "sha512-4fCk79wshMdzMp2rH06qWrJE4iolqLhCUH+OiuIgU++RB0+94NlDL81atO7GX55uUKueo0txHNtvEyI6D7WdMw==",
+      "license": "MIT",
+      "dependencies": {
+        "safer-buffer": ">= 2.1.2 < 3.0.0"
+      },
+      "engines": {
+        "node": ">=0.10.0"
       }
     },
     "node_modules/ignore": {
@@ -6877,6 +7021,18 @@
       "dev": true,
       "license": "MIT"
     },
+    "node_modules/nth-check": {
+      "version": "2.1.1",
+      "resolved": "https://registry.npmjs.org/nth-check/-/nth-check-2.1.1.tgz",
+      "integrity": "sha512-lqjrjmaOoAnWfMmBPL+XNnynZh2+swxiX3WUE0s4yEHI6m+AwrK2UZOimIRl3X/4QctVqS8AiZjFqyOGrMXb/w==",
+      "license": "BSD-2-Clause",
+      "dependencies": {
+        "boolbase": "^1.0.0"
+      },
+      "funding": {
+        "url": "https://github.com/fb55/nth-check?sponsor=1"
+      }
+    },
     "node_modules/object-assign": {
       "version": "4.1.1",
       "resolved": "https://registry.npmjs.org/object-assign/-/object-assign-4.1.1.tgz",
@@ -7125,6 +7281,55 @@
       },
       "engines": {
         "node": ">=6"
+      }
+    },
+    "node_modules/parse5": {
+      "version": "7.3.0",
+      "resolved": "https://registry.npmjs.org/parse5/-/parse5-7.3.0.tgz",
+      "integrity": "sha512-IInvU7fabl34qmi9gY8XOVxhYyMyuH2xUNpb2q8/Y+7552KlejkRvqvD19nMoUW/uQGGbqNpA6Tufu5FL5BZgw==",
+      "license": "MIT",
+      "dependencies": {
+        "entities": "^6.0.0"
+      },
+      "funding": {
+        "url": "https://github.com/inikulin/parse5?sponsor=1"
+      }
+    },
+    "node_modules/parse5-htmlparser2-tree-adapter": {
+      "version": "7.1.0",
+      "resolved": "https://registry.npmjs.org/parse5-htmlparser2-tree-adapter/-/parse5-htmlparser2-tree-adapter-7.1.0.tgz",
+      "integrity": "sha512-ruw5xyKs6lrpo9x9rCZqZZnIUntICjQAd0Wsmp396Ul9lN/h+ifgVV1x1gZHi8euej6wTfpqX8j+BFQxF0NS/g==",
+      "license": "MIT",
+      "dependencies": {
+        "domhandler": "^5.0.3",
+        "parse5": "^7.0.0"
+      },
+      "funding": {
+        "url": "https://github.com/inikulin/parse5?sponsor=1"
+      }
+    },
+    "node_modules/parse5-parser-stream": {
+      "version": "7.1.2",
+      "resolved": "https://registry.npmjs.org/parse5-parser-stream/-/parse5-parser-stream-7.1.2.tgz",
+      "integrity": "sha512-JyeQc9iwFLn5TbvvqACIF/VXG6abODeB3Fwmv/TGdLk2LfbWkaySGY72at4+Ty7EkPZj854u4CrICqNk2qIbow==",
+      "license": "MIT",
+      "dependencies": {
+        "parse5": "^7.0.0"
+      },
+      "funding": {
+        "url": "https://github.com/inikulin/parse5?sponsor=1"
+      }
+    },
+    "node_modules/parse5/node_modules/entities": {
+      "version": "6.0.1",
+      "resolved": "https://registry.npmjs.org/entities/-/entities-6.0.1.tgz",
+      "integrity": "sha512-aN97NXWF6AWBTahfVOIrB/NShkzi5H7F9r1s9mD3cDj4Ko5f2qhhVoYMibXF7GlLveb/D2ioWay8lxI97Ven3g==",
+      "license": "BSD-2-Clause",
+      "engines": {
+        "node": ">=0.12"
+      },
+      "funding": {
+        "url": "https://github.com/fb55/entities?sponsor=1"
       }
     },
     "node_modules/parseley": {
@@ -7715,6 +7920,12 @@
       "funding": {
         "url": "https://github.com/sponsors/ljharb"
       }
+    },
+    "node_modules/safer-buffer": {
+      "version": "2.1.2",
+      "resolved": "https://registry.npmjs.org/safer-buffer/-/safer-buffer-2.1.2.tgz",
+      "integrity": "sha512-YZo3K82SD7Riyi0E1EQPojLz7kpepnSQI9IyPbHHg1XXXevb5dJI7tpyN2ADxGcQbHG7vcyRHk0cbwqcQriUtg==",
+      "license": "MIT"
     },
     "node_modules/scheduler": {
       "version": "0.27.0",
@@ -8648,6 +8859,15 @@
         "url": "https://github.com/sponsors/ljharb"
       }
     },
+    "node_modules/undici": {
+      "version": "7.22.0",
+      "resolved": "https://registry.npmjs.org/undici/-/undici-7.22.0.tgz",
+      "integrity": "sha512-RqslV2Us5BrllB+JeiZnK4peryVTndy9Dnqq62S3yYRRTj0tFQCwEniUy2167skdGOy3vqRzEvl1Dm4sV2ReDg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=20.18.1"
+      }
+    },
     "node_modules/undici-types": {
       "version": "6.19.8",
       "resolved": "https://registry.npmjs.org/undici-types/-/undici-types-6.19.8.tgz",
@@ -8877,6 +9097,28 @@
       "license": "MIT",
       "engines": {
         "node": ">= 8"
+      }
+    },
+    "node_modules/whatwg-encoding": {
+      "version": "3.1.1",
+      "resolved": "https://registry.npmjs.org/whatwg-encoding/-/whatwg-encoding-3.1.1.tgz",
+      "integrity": "sha512-6qN4hJdMwfYBtE3YBTTHhoeuUrDBPZmbQaxWAqSALV/MeEnR5z1xd8UKud2RAkFoPkmB+hli1TZSnyi84xz1vQ==",
+      "deprecated": "Use @exodus/bytes instead for a more spec-conformant and faster implementation",
+      "license": "MIT",
+      "dependencies": {
+        "iconv-lite": "0.6.3"
+      },
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/whatwg-mimetype": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/whatwg-mimetype/-/whatwg-mimetype-4.0.0.tgz",
+      "integrity": "sha512-QaKxh0eNIi2mE9p2vEdzfagOKHCcj1pJ56EEHGQOVxp8r9/iszLUUV7v89x9O1p/T+NlTM5W7jW6+cz4Fq1YVg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=18"
       }
     },
     "node_modules/which": {

--- a/package.json
+++ b/package.json
@@ -18,6 +18,7 @@
     "@radix-ui/react-slot": "^1.2.2",
     "@react-email/components": "^1.0.3",
     "@react-email/render": "^2.0.1",
+    "cheerio": "^1.2.0",
     "class-variance-authority": "^0.7.1",
     "clsx": "^2.1.1",
     "framer-motion": "^12.23.24",
@@ -40,6 +41,7 @@
   },
   "devDependencies": {
     "@tailwindcss/postcss": "^4",
+    "@types/cheerio": "^0.22.35",
     "@types/node": "^20",
     "@types/p5": "^1.7.6",
     "@types/qrcode": "^1.5.6",

--- a/src/app/music/[slug]/page.tsx
+++ b/src/app/music/[slug]/page.tsx
@@ -1,50 +1,102 @@
-import MotionTitle from '@/components/MotionTitle'
-import MusicPlayer from '@/components/MusicPlayer'
-import colors from '@/lib/colors'
-import { getSongBySlug } from '@/lib/songs'
-import Image from 'next/image'
-import { notFound } from 'next/navigation'
+import MotionTitle from "@/components/MotionTitle";
+import MusicPlayer from "@/components/MusicPlayer";
+import colors from "@/lib/colors";
+import { getDistroKidLinks } from "@/lib/distrokid";
+import { getSongBySlug } from "@/lib/songs";
+import Image from "next/image";
+import { notFound } from "next/navigation";
+
 type Props = {
-  params: Promise<{ slug: string }>
-}
+    params: Promise<{ slug: string }>;
+};
 
 export default async function Song({ params }: Props) {
-  const { slug } = await params
-  const song = await getSongBySlug(slug)
+    const { slug } = await params;
+    const song = await getSongBySlug(slug);
 
-  if (!song) {
-    notFound()
-  }
-  console.log(song.streamingLinks)
-  const bandcamp = song.streamingLinks.filter(
-    (link) => link.label.toLowerCase() === 'bandcamp',
-  )[0]
-  console.log(bandcamp)
-  return (
-    <main>
-      <MotionTitle />
-      <section className='h-screen w-screen'>
-        <MusicPlayer song={song} />
-      </section>
-      <section className='flex' style={{ backgroundColor: colors[2] }}>
-        <Image
-          src={song.images[0]}
-          height='500'
-          width='500'
-          alt='Fake it album art feature a psychedelic pug'
-        />
-        <div className='flex-1 grid place-items-center'>
-          <div>
-            <h1 className='italic text-6xl'>Want to support my music?</h1>
-            <h2>The best way is to buy this track on BandCamp!</h2>
-            <button className='h-18 w-full bg-amber-500 flex border-l-4 border-amber-500'>
-              <div className=' flex-1 '>
-                <h3 className='flex-1'>Buy this track on BandCamp</h3>
-              </div>
-            </button>
-          </div>
-        </div>
-      </section>
-    </main>
-  )
+    if (!song) {
+        notFound();
+    }
+
+    const bandcamp = song.streamingLinks.find((link) => link.label.toLowerCase() === "bandcamp");
+    const distrokid = song.streamingLinks.find((link) => link.label.toLowerCase() === "distrokid");
+    const streamingLinks = distrokid ? await getDistroKidLinks(distrokid.url) : [];
+
+    return (
+        <main className="overflow-x-hidden">
+            <MotionTitle />
+            <section className="h-screen w-screen">
+                <MusicPlayer song={song} />
+            </section>
+
+            {bandcamp && (
+                <section className="flex flex-col md:flex-row items-stretch" style={{ backgroundColor: colors[3] }}>
+                    <div className="hidden md:block relative md:w-[500px] min-h-[500px] shrink-0">
+                        <Image src={song.images[0]} fill className="object-cover" alt={`${song.name} album art`} />
+                    </div>
+                    <div className="flex-1 flex items-center justify-center px-10 py-16">
+                        <div className="max-w-lg space-y-6">
+                            <p className="text-sm font-bold uppercase tracking-widest opacity-70">
+                                Support independent music
+                            </p>
+                            <h1
+                                className="italic font-bold leading-tight"
+                                style={{ fontSize: "clamp(2rem, 5vw, 3.5rem)" }}
+                            >
+                                Want to support my music?
+                            </h1>
+                            <p className="text-lg opacity-80">
+                                The best way is to buy this track directly on Bandcamp — 100% of your purchase goes
+                                straight to the artist.
+                            </p>
+                            <a
+                                href={bandcamp.url}
+                                target="_blank"
+                                rel="noopener noreferrer"
+                                className="flex items-center gap-4 rounded-xl px-6 py-4 font-bold text-white text-lg shadow-lg transition-transform hover:scale-[1.02] active:scale-[0.98]"
+                                style={{ backgroundColor: "#1da0c3" }}
+                            >
+                                <svg
+                                    xmlns="http://www.w3.org/2000/svg"
+                                    viewBox="0 0 24 24"
+                                    fill="currentColor"
+                                    className="w-7 h-7 shrink-0"
+                                    aria-hidden="true"
+                                >
+                                    <path d="M0 18.75l7.437-13.5H24l-7.438 13.5z" />
+                                </svg>
+                                <span>Buy &ldquo;{song.name}&rdquo; on Bandcamp</span>
+                            </a>
+                        </div>
+                    </div>
+                </section>
+            )}
+
+            {streamingLinks.length > 0 && (
+                <section className="flex flex-col items-center py-16 px-4 gap-8" style={{ backgroundColor: colors[9] }}>
+                    <h2 className="text-white text-2xl font-bold tracking-wide">Stream on all platforms</h2>
+                    <div className="flex flex-wrap justify-center gap-4 max-w-2xl">
+                        {streamingLinks.map((link) => (
+                            <a
+                                key={link.service}
+                                href={link.url}
+                                target="_blank"
+                                rel="noopener noreferrer"
+                                className="flex items-center gap-3 bg-white/10 hover:bg-white/20 active:bg-white/30 transition-colors rounded-xl px-5 py-3 text-white font-semibold shadow"
+                            >
+                                <Image
+                                    src={link.iconUrl}
+                                    alt={link.service}
+                                    width={28}
+                                    height={28}
+                                    className="rounded-md"
+                                />
+                                {link.service}
+                            </a>
+                        ))}
+                    </div>
+                </section>
+            )}
+        </main>
+    );
 }

--- a/src/components/MusicPlayer.tsx
+++ b/src/components/MusicPlayer.tsx
@@ -54,7 +54,6 @@ export default function MusicSection({ song }: { song: Song }) {
   const sketch = useCallback((p: p5) => visualizerSketch(p, analyserRef), [])
   const src = song.audioFiles[0]
   const img = song.images[0]
-  console.log(img)
   return (
     <div className='h-full w-full relative'>
       <div className='flex absolute bottom-0 xl:bottom-10 xl:right-10 w-full xl:w-150 h-25 bg-white'>

--- a/src/lib/distrokid.ts
+++ b/src/lib/distrokid.ts
@@ -1,0 +1,76 @@
+import * as cheerio from 'cheerio'
+import 'server-only'
+
+export type StreamingServiceLink = {
+  service: string
+  url: string
+  iconUrl: string
+}
+
+function extractServiceName(iconSrc: string): string {
+  const filename = iconSrc.split('/').pop()?.split('?')[0] ?? ''
+  const name = filename.replace(/\.(png|jpg|jpeg|svg|webp)$/i, '').toLowerCase()
+
+  const aliases: Record<string, string> = {
+    applemusic: 'Apple Music',
+    itunes: 'iTunes',
+    spotify: 'Spotify',
+    amazonmusic: 'Amazon Music',
+    youtube: 'YouTube Music',
+    youtubemusic: 'YouTube Music',
+    tidal: 'Tidal',
+    deezer: 'Deezer',
+    pandora: 'Pandora',
+    iheartradio: 'iHeart Radio',
+    soundcloud: 'SoundCloud',
+  }
+
+  for (const [key, label] of Object.entries(aliases)) {
+    if (name.includes(key)) return label
+  }
+
+  return name.charAt(0).toUpperCase() + name.slice(1)
+}
+
+export async function getDistroKidLinks(
+  url: string,
+): Promise<StreamingServiceLink[]> {
+  let html: string
+  try {
+    const res = await fetch(url, {
+      next: { revalidate: 60 * 60 * 24 }, // cache for 24 hours
+      headers: {
+        'User-Agent': 'Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/124.0.0.0 Safari/537.36',
+        'Accept': 'text/html,application/xhtml+xml,application/xml;q=0.9,image/avif,image/webp,*/*;q=0.8',
+        'Accept-Language': 'en-US,en;q=0.9',
+        'Accept-Encoding': 'gzip, deflate, br',
+        'Cache-Control': 'no-cache',
+        'Pragma': 'no-cache',
+        'Sec-Fetch-Dest': 'document',
+        'Sec-Fetch-Mode': 'navigate',
+        'Sec-Fetch-Site': 'none',
+        'Upgrade-Insecure-Requests': '1',
+      },
+    })
+    if (!res.ok) return []
+    html = await res.text()
+  } catch {
+    return []
+  }
+
+  const $ = cheerio.load(html)
+  const links: StreamingServiceLink[] = []
+
+  $('a:has(.hyperDspLink)').each((_, el) => {
+    const href = $(el).attr('href')
+    const iconSrc = $(el).find('img').attr('src')
+    if (!href || !iconSrc) return
+    links.push({
+      service: extractServiceName(iconSrc),
+      url: href,
+      iconUrl: iconSrc,
+    })
+  })
+
+  return links
+}


### PR DESCRIPTION
### TL;DR

Added DistroKid link scraping functionality to automatically extract streaming platform links from DistroKid pages and display them on song pages.

### What changed?

- Added `cheerio` dependency for HTML parsing and web scraping
- Created `src/lib/distrokid.ts` with functions to scrape streaming service links from DistroKid pages
- Updated song pages to fetch and display streaming platform links when a DistroKid URL is present
- Configured Next.js to allow images from `distrokid.imgix.net` domain
- Enhanced the song page layout with a dedicated streaming links section
- Added Claude settings to allow web fetching from distrokid.com domain
- Disabled Postman dotenv detection notifications in VS Code settings

### How to test?

1. Navigate to a song page that has a DistroKid streaming link configured
2. Verify that streaming platform buttons appear in the new "Stream on all platforms" section
3. Click on the streaming platform links to ensure they redirect correctly
4. Test that the Bandcamp support section still displays when a Bandcamp link is present

### Why make this change?

This enhancement improves the user experience by automatically providing direct links to all major streaming platforms where the song is available, eliminating the need to manually maintain individual streaming links and ensuring users can easily find the song on their preferred platform.